### PR TITLE
[CHECK-ONLY] [HUDI-7493] Consistent naming of Cleaner configuration parameters #10851

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
@@ -53,16 +53,18 @@ public class HoodieCleanConfig extends HoodieConfig {
   private static final String CLEANER_FILE_VERSIONS_RETAINED_KEY = "hoodie.cleaner.fileversions.retained";
 
   public static final ConfigProperty<String> AUTO_CLEAN = ConfigProperty
-      .key("hoodie.clean.automatic")
+      .key("hoodie.cleaner.automatic")
       .defaultValue("true")
+      .withAlternatives("hoodie.clean.automatic")
       .markAdvanced()
       .withDocumentation("When enabled, the cleaner table service is invoked immediately after each commit, "
           + "to delete older file slices. It's recommended to enable this, to ensure metadata and data storage "
           + "growth is bounded.");
 
   public static final ConfigProperty<String> ASYNC_CLEAN = ConfigProperty
-      .key("hoodie.clean.async")
+      .key("hoodie.cleaner.async.enabled")
       .defaultValue("false")
+      .withAlternatives("hoodie.clean.async")
       .withDocumentation("Only applies when " + AUTO_CLEAN.key() + " is turned on. "
           + "When turned on runs cleaner async with writing, which can speed up overall write performance.");
 
@@ -118,28 +120,32 @@ public class HoodieCleanConfig extends HoodieConfig {
           + "the minimum number of file slices to retain in each file group, during cleaning.");
 
   public static final ConfigProperty<String> CLEAN_TRIGGER_STRATEGY = ConfigProperty
-      .key("hoodie.clean.trigger.strategy")
+      .key("hoodie.cleaner.trigger.strategy")
       .defaultValue(CleaningTriggerStrategy.NUM_COMMITS.name())
+      .withAlternatives("hoodie.clean.trigger.strategy")
       .markAdvanced()
       .withDocumentation(CleaningTriggerStrategy.class);
 
   public static final ConfigProperty<String> CLEAN_MAX_COMMITS = ConfigProperty
-      .key("hoodie.clean.max.commits")
+      .key("hoodie.cleaner.trigger.max.commits")
       .defaultValue("1")
+      .withAlternatives("hoodie.clean.max.commits")
       .markAdvanced()
       .withDocumentation("Number of commits after the last clean operation, before scheduling of a new clean is attempted.");
 
   public static final ConfigProperty<String> CLEANER_INCREMENTAL_MODE_ENABLE = ConfigProperty
-      .key("hoodie.cleaner.incremental.mode")
+      .key("hoodie.cleaner.incremental.enabled")
       .defaultValue("true")
+      .withAlternatives("hoodie.cleaner.incremental.mode")
       .markAdvanced()
       .withDocumentation("When enabled, the plans for each cleaner service run is computed incrementally off the events "
           + "in the timeline, since the last cleaner run. This is much more efficient than obtaining listings for the full "
           + "table for each planning (even with a metadata table).");
 
   public static final ConfigProperty<String> FAILED_WRITES_CLEANER_POLICY = ConfigProperty
-      .key("hoodie.cleaner.policy.failed.writes")
+      .key("hoodie.cleaner.failed.writes.policy")
       .defaultValue(HoodieFailedWritesCleaningPolicy.EAGER.name())
+      .withAlternatives("hoodie.cleaner.policy.failed.writes")
       .withInferFunction(cfg -> {
         Option<String> writeConcurrencyModeOpt = Option.ofNullable(cfg.getString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE));
         if (!writeConcurrencyModeOpt.isPresent()
@@ -168,8 +174,9 @@ public class HoodieCleanConfig extends HoodieConfig {
           + "performance..");
 
   public static final ConfigProperty<Boolean> ALLOW_MULTIPLE_CLEANS = ConfigProperty
-      .key("hoodie.clean.allow.multiple")
+      .key("hoodie.cleaner.multiple.enabled")
       .defaultValue(true)
+      .withAlternatives("hoodie.clean.allow.multiple")
       .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Allows scheduling/executing multiple cleans by enabling this config. If users prefer to strictly ensure clean requests should be mutually exclusive, "

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -3350,7 +3350,7 @@ public class HoodieWriteConfig extends HoodieConfig {
             HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key(), InProcessLockProvider.class.getName()));
       }
 
-      // We check if "hoodie.cleaner.policy.failed.writes"
+      // We check if "hoodie.cleaner.failed.writes.policy"
       // is properly set to LAZY for multi-writers
       WriteConcurrencyMode writeConcurrencyMode = writeConfig.getWriteConcurrencyMode();
       if (writeConcurrencyMode.supportsMultiWriter()) {
@@ -3378,7 +3378,7 @@ public class HoodieWriteConfig extends HoodieConfig {
         checkArgument(!writeConfig.getString(HoodieCleanConfig.FAILED_WRITES_CLEANER_POLICY)
             .equals(HoodieFailedWritesCleaningPolicy.EAGER.name()),
             String.format(
-                "To enable %s, set hoodie.cleaner.policy.failed.writes=LAZY",
+                "To enable %s, set hoodie.cleaner.failed.writes.policy=LAZY",
                 writeConcurrencyMode.name()));
       }
       if (writeConcurrencyMode == WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleaningTriggerStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleaningTriggerStrategy.java
@@ -24,6 +24,6 @@ import org.apache.hudi.common.config.EnumFieldDescription;
 @EnumDescription("Controls when cleaning is scheduled.")
 public enum CleaningTriggerStrategy {
     // trigger cleaning when reach n commits
-    @EnumFieldDescription("Trigger the cleaning service every N commits, determined by `hoodie.clean.max.commits`.")
+    @EnumFieldDescription("Trigger the cleaning service every N commits, determined by `hoodie.cleaner.trigger.max.commits`.")
     NUM_COMMITS
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -51,8 +51,6 @@ import static org.apache.hudi.common.model.HoodieCleaningPolicy.KEEP_LATEST_BY_H
 import static org.apache.hudi.common.model.HoodieCleaningPolicy.KEEP_LATEST_COMMITS;
 import static org.apache.hudi.common.model.HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS;
 import static org.apache.hudi.config.HoodieArchivalConfig.ASYNC_ARCHIVE;
-import static org.apache.hudi.config.HoodieCleanConfig.ASYNC_CLEAN;
-import static org.apache.hudi.config.HoodieCleanConfig.AUTO_CLEAN;
 import static org.apache.hudi.config.HoodieCleanConfig.FAILED_WRITES_CLEANER_POLICY;
 import static org.apache.hudi.config.HoodieClusteringConfig.ASYNC_CLUSTERING_ENABLE;
 import static org.apache.hudi.config.HoodieCompactionConfig.INLINE_COMPACT;
@@ -214,8 +212,8 @@ public class TestHoodieWriteConfig {
             put(HoodieTableConfig.TYPE.key(), tableType.name());
             put(ASYNC_CLUSTERING_ENABLE.key(), "true");
             put(INLINE_COMPACT.key(), "true");
-            put(AUTO_CLEAN.key(), "true");
-            put(ASYNC_CLEAN.key(), "false");
+            put("hoodie.clean.automatic", "true");
+            put("hoodie.clean.async", "false");
             put(HoodieWriteConfig.AUTO_ADJUST_LOCK_CONFIGS.key(), "true");
           }
         }), true, true, true,
@@ -229,8 +227,8 @@ public class TestHoodieWriteConfig {
             put(HoodieTableConfig.TYPE.key(), tableType.name());
             put(ASYNC_CLUSTERING_ENABLE.key(), "false");
             put(INLINE_COMPACT.key(), "true");
-            put(AUTO_CLEAN.key(), "true");
-            put(ASYNC_CLEAN.key(), "true");
+            put("hoodie.clean.automatic", "true");
+            put("hoodie.clean.async", "true");
             put(HoodieWriteConfig.AUTO_ADJUST_LOCK_CONFIGS.key(), "true");
           }
         }), true, true, true,
@@ -244,8 +242,8 @@ public class TestHoodieWriteConfig {
             put(HoodieTableConfig.TYPE.key(), tableType.name());
             put(ASYNC_CLUSTERING_ENABLE.key(), "false");
             put(INLINE_COMPACT.key(), "false");
-            put(AUTO_CLEAN.key(), "true");
-            put(ASYNC_CLEAN.key(), "false");
+            put("hoodie.clean.automatic", "true");
+            put("hoodie.clean.async", "false");
             put(HoodieWriteConfig.AUTO_ADJUST_LOCK_CONFIGS.key(), "true");
           }
         }), true,
@@ -262,8 +260,8 @@ public class TestHoodieWriteConfig {
             put(HoodieTableConfig.TYPE.key(), tableType.name());
             put(ASYNC_CLUSTERING_ENABLE.key(), "false");
             put(INLINE_COMPACT.key(), "true");
-            put(AUTO_CLEAN.key(), "true");
-            put(ASYNC_CLEAN.key(), "false");
+            put("hoodie.clean.automatic", "true");
+            put("hoodie.clean.async", "false");
             put(HoodieWriteConfig.AUTO_ADJUST_LOCK_CONFIGS.key(), "true");
           }
         }), true, false, true,
@@ -277,8 +275,8 @@ public class TestHoodieWriteConfig {
             put(HoodieTableConfig.TYPE.key(), tableType.name());
             put(ASYNC_CLUSTERING_ENABLE.key(), "true");
             put(INLINE_COMPACT.key(), "false");
-            put(AUTO_CLEAN.key(), "true");
-            put(ASYNC_CLEAN.key(), "true");
+            put("hoodie.clean.automatic", "true");
+            put("hoodie.clean.async", "true");
             put(ASYNC_ARCHIVE.key(), "true");
             put(HoodieWriteConfig.AUTO_ADJUST_LOCK_CONFIGS.key(), "true");
           }
@@ -347,8 +345,8 @@ public class TestHoodieWriteConfig {
             put(HoodieTableConfig.TYPE.key(), tableType.name());
             put(ASYNC_CLUSTERING_ENABLE.key(), "false");
             put(INLINE_COMPACT.key(), "true");
-            put(AUTO_CLEAN.key(), "true");
-            put(ASYNC_CLEAN.key(), "true");
+            put("hoodie.clean.automatic", "true");
+            put("hoodie.clean.async", "true");
             put(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key(),
                 ZookeeperBasedLockProvider.class.getName());
             put(HoodieWriteConfig.AUTO_ADJUST_LOCK_CONFIGS.key(), "true");
@@ -424,8 +422,8 @@ public class TestHoodieWriteConfig {
             put(HoodieMetadataConfig.ENABLE.key(), "false");
             put(ASYNC_CLUSTERING_ENABLE.key(), "true");
             put(INLINE_COMPACT.key(), "true");
-            put(AUTO_CLEAN.key(), "true");
-            put(ASYNC_CLEAN.key(), "false");
+            put("hoodie.clean.automatic", "true");
+            put("hoodie.clean.async", "false");
             put(HoodieWriteConfig.AUTO_ADJUST_LOCK_CONFIGS.key(), "true");
           }
         }), true, true, true,
@@ -439,8 +437,8 @@ public class TestHoodieWriteConfig {
           {
             put(ASYNC_CLUSTERING_ENABLE.key(), "true");
             put(INLINE_COMPACT.key(), "true");
-            put(AUTO_CLEAN.key(), "true");
-            put(ASYNC_CLEAN.key(), "false");
+            put("hoodie.clean.automatic", "true");
+            put("hoodie.clean.async", "false");
             put(WRITE_CONCURRENCY_MODE.key(),
                 WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name());
             put(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key(),

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -517,7 +517,7 @@ public class TestHoodieWriteConfig {
         .withWriteConcurrencyMode(WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL)
         .build();
 
-    // Verify automatically set hoodie.cleaner.policy.failed.writes=LAZY for non-blocking concurrency control
+    // Verify automatically set hoodie.cleaner.failed.writes.policy=LAZY for non-blocking concurrency control
     verifyConcurrencyControlRelatedConfigs(writeConfig,
         true, true, true,
         WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL, HoodieFailedWritesCleaningPolicy.LAZY,

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -2392,7 +2392,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     HoodieEngineContext engineContext = new HoodieJavaEngineContext(hadoopConf);
 
     Properties props = new Properties();
-    props.put(HoodieCleanConfig.ALLOW_MULTIPLE_CLEANS.key(), "false");
+    props.put("hoodie.clean.allow.multiple", "false");
     HoodieWriteConfig writeConfig = getWriteConfigBuilder(true, true, false).withProps(props).build();
 
     // Perform three writes so we can initiate a clean

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -3074,7 +3074,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
 
     Properties props = new Properties();
-    props.put(HoodieCleanConfig.ALLOW_MULTIPLE_CLEANS.key(), "false");
+    props.put("hoodie.clean.allow.multiple", "false");
     HoodieWriteConfig writeConfig = getWriteConfigBuilder(true, true, false).withProps(props).build();
 
     // Perform three writes so we can initiate a clean

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -411,7 +411,7 @@ public class TestCleaner extends HoodieCleanerTestBase {
   }
 
   /**
-   * Tests no more than 1 clean is scheduled if hoodie.clean.allow.multiple config is set to false.
+   * Tests no more than 1 clean is scheduled if hoodie.cleaner.multiple.enabled config is set to false.
    */
   @Test
   public void testMultiClean() {
@@ -458,7 +458,7 @@ public class TestCleaner extends HoodieCleanerTestBase {
       // Try to schedule another clean
       String newCleanInstantTime = "00" + index++;
       HoodieCleanMetadata cleanMetadata = client.clean(newCleanInstantTime);
-      // When hoodie.clean.allow.multiple is set to false, a new clean action should not be scheduled.
+      // When hoodie.cleaner.multiple.enabled is set to false, a new clean action should not be scheduled.
       // The existing requested clean should complete execution.
       assertNotNull(cleanMetadata);
       assertTrue(metaClient.reloadActiveTimeline().getCleanerTimeline()

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -725,40 +725,45 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Target IO in MB for per compaction (both read and write), default 500 GB");
 
   public static final ConfigOption<Boolean> CLEAN_ASYNC_ENABLED = ConfigOptions
-      .key("clean.async.enabled")
+      .key("hoodie.cleaner.async.enabled")
       .booleanType()
       .defaultValue(true)
+      .withFallbackKeys("clean.async.enabled")
       .withDescription("Whether to cleanup the old commits immediately on new commits, enabled by default");
 
   @AdvancedConfig
   public static final ConfigOption<String> CLEAN_POLICY = ConfigOptions
-      .key("clean.policy")
+      .key("hoodie.cleaner.policy")
       .stringType()
       .defaultValue(HoodieCleaningPolicy.KEEP_LATEST_COMMITS.name())
+      .withFallbackKeys("clean.policy")
       .withDescription("Clean policy to manage the Hudi table. Available option: KEEP_LATEST_COMMITS, KEEP_LATEST_FILE_VERSIONS, KEEP_LATEST_BY_HOURS."
           + "Default is KEEP_LATEST_COMMITS.");
 
   public static final ConfigOption<Integer> CLEAN_RETAIN_COMMITS = ConfigOptions
-      .key("clean.retain_commits")
+      .key("hoodie.cleaner.commits.retained")
       .intType()
       .defaultValue(30)// default 30 commits
+      .withFallbackKeys("clean.retain_commits")
       .withDescription("Number of commits to retain. So data will be retained for num_of_commits * time_between_commits (scheduled).\n"
           + "This also directly translates into how much you can incrementally pull on this table, default 30");
 
   @AdvancedConfig
   public static final ConfigOption<Integer> CLEAN_RETAIN_HOURS = ConfigOptions
-      .key("clean.retain_hours")
+      .key("hoodie.cleaner.hours.retained")
       .intType()
       .defaultValue(24)// default 24 hours
+      .withFallbackKeys("clean.retain_hours")
       .withDescription("Number of hours for which commits need to be retained. This config provides a more flexible option as"
           + "compared to number of commits retained for cleaning service. Setting this property ensures all the files, but the latest in a file group,"
           + " corresponding to commits with commit times older than the configured number of hours to be retained are cleaned.");
 
   @AdvancedConfig
   public static final ConfigOption<Integer> CLEAN_RETAIN_FILE_VERSIONS = ConfigOptions
-      .key("clean.retain_file_versions")
+      .key("hoodie.cleaner.fileversions.retained")
       .intType()
       .defaultValue(5)// default 5 version
+      .withFallbackKeys("clean.retain_file_versions")
       .withDescription("Number of file versions to retain. default 5");
 
   public static final ConfigOption<Integer> ARCHIVE_MAX_COMMITS = ConfigOptions

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
@@ -224,7 +224,7 @@ public class TestStreamWriteOperatorCoordinator {
     reset();
     // override the default configuration
     Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
-    conf.setString(HoodieCleanConfig.FAILED_WRITES_CLEANER_POLICY.key(), HoodieFailedWritesCleaningPolicy.LAZY.name());
+    conf.setString("hoodie.cleaner.incremental.mode", HoodieFailedWritesCleaningPolicy.LAZY.name());
     OperatorCoordinator.Context context = new MockOperatorCoordinatorContext(new OperatorID(), 1);
     coordinator = new StreamWriteOperatorCoordinator(conf, context);
     coordinator.start();

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
@@ -25,7 +25,6 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.FileSystemViewStorageType;
-import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.OptionsResolver;
@@ -662,7 +661,7 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
 
   @Test
   public void testRollbackFailedWritesWithLazyCleanPolicy() throws Exception {
-    conf.setString(HoodieCleanConfig.FAILED_WRITES_CLEANER_POLICY.key(), HoodieFailedWritesCleaningPolicy.LAZY.name());
+    conf.setString("hoodie.cleaner.incremental.mode", HoodieFailedWritesCleaningPolicy.LAZY.name());
 
     preparePipeline()
         .consume(TestData.DATA_SET_INSERT)

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/cluster/ITTestHoodieFlinkClustering.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/cluster/ITTestHoodieFlinkClustering.java
@@ -355,7 +355,7 @@ public class ITTestHoodieFlinkClustering {
     // set archive commits
     conf.setInteger(FlinkOptions.ARCHIVE_MAX_COMMITS.key(), 2);
     conf.setInteger(FlinkOptions.ARCHIVE_MIN_COMMITS.key(), 1);
-    conf.setInteger(FlinkOptions.CLEAN_RETAIN_COMMITS.key(), 0);
+    conf.setInteger("clean.retain_commits", 0);
 
     // set table schema
     CompactionUtil.setAvroSchema(conf, metaClient);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
@@ -451,7 +451,7 @@ public class TestHoodieTableFactory {
         .primaryKey("f0")
         .build();
     // set up new retains commits that is less than min archive commits
-    this.conf.setString(FlinkOptions.CLEAN_RETAIN_COMMITS.key(), "11");
+    this.conf.setString("clean.retain_commits", "11");
 
     final MockContext sourceContext1 = MockContext.getInstance(this.conf, schema1, "f2");
     final HoodieTableSource tableSource1 = (HoodieTableSource) new HoodieTableFactory().createDynamicTableSource(sourceContext1);
@@ -461,7 +461,7 @@ public class TestHoodieTableFactory {
 
     // set up new retains commits that is greater than min archive commits
     final int retainCommits = FlinkOptions.ARCHIVE_MIN_COMMITS.defaultValue() + 5;
-    this.conf.setInteger(FlinkOptions.CLEAN_RETAIN_COMMITS.key(), retainCommits);
+    this.conf.setInteger("clean.retain_commits", retainCommits);
 
     final MockContext sourceContext2 = MockContext.getInstance(this.conf, schema1, "f2");
     final HoodieTableSource tableSource2 = (HoodieTableSource) new HoodieTableFactory().createDynamicTableSource(sourceContext2);
@@ -662,7 +662,7 @@ public class TestHoodieTableFactory {
         .primaryKey("f0")
         .build();
     // set up new retains commits that is less than min archive commits
-    this.conf.setString(FlinkOptions.CLEAN_RETAIN_COMMITS.key(), "11");
+    this.conf.setString("clean.retain_commits", "11");
 
     final MockContext sinkContext1 = MockContext.getInstance(this.conf, schema1, "f2");
     final HoodieTableSink tableSink1 = (HoodieTableSink) new HoodieTableFactory().createDynamicTableSink(sinkContext1);
@@ -672,7 +672,7 @@ public class TestHoodieTableFactory {
 
     // set up new retains commits that is greater than min archive commits
     final int retainCommits = FlinkOptions.ARCHIVE_MIN_COMMITS.defaultValue() + 5;
-    this.conf.setInteger(FlinkOptions.CLEAN_RETAIN_COMMITS.key(), retainCommits);
+    this.conf.setInteger("clean.retain_commits", retainCommits);
 
     final MockContext sinkContext2 = MockContext.getInstance(this.conf, schema1, "f2");
     final HoodieTableSink tableSink2 = (HoodieTableSink) new HoodieTableFactory().createDynamicTableSink(sinkContext2);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
@@ -998,7 +998,7 @@ public class TestInputFormat {
     options.put(FlinkOptions.QUERY_TYPE.key(), FlinkOptions.QUERY_TYPE_INCREMENTAL);
     options.put(FlinkOptions.ARCHIVE_MIN_COMMITS.key(), "3");
     options.put(FlinkOptions.ARCHIVE_MAX_COMMITS.key(), "4");
-    options.put(FlinkOptions.CLEAN_RETAIN_COMMITS.key(), "2");
+    options.put("clean.retain_commits", "2");
     // disable the metadata table to make the archiving behavior deterministic
     options.put(FlinkOptions.METADATA_ENABLED.key(), "false");
     options.put("hoodie.commits.archival.batch", "1");

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
@@ -447,7 +447,7 @@ class TestRecordLevelIndex extends RecordLevelIndexTestBase {
     val hudiOpts = commonOpts ++ Map(
       DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name(),
       HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key() -> "optimistic_concurrency_control",
-      HoodieCleanConfig.FAILED_WRITES_CLEANER_POLICY.key() -> "LAZY",
+      "hoodie.cleaner.incremental.mode" -> "LAZY",
       HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key() -> "org.apache.hudi.client.transaction.lock.FileSystemBasedLockProvider",
       HoodieLockConfig.WRITE_CONFLICT_RESOLUTION_STRATEGY_CLASS_NAME.key() -> classOf[PreferWriterConflictResolutionStrategy].getName
     )

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/HoodieCDCTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/HoodieCDCTestBase.scala
@@ -56,7 +56,7 @@ abstract class HoodieCDCTestBase extends HoodieSparkClientTestBase {
     PRECOMBINE_FIELD.key -> "timestamp",
     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
     HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "1",
-    HoodieCleanConfig.AUTO_CLEAN.key -> "false"
+    "hoodie.clean.automatic" -> "false"
   )
 
   @BeforeEach override def setUp(): Unit = {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -28,7 +28,6 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.StringUtils;
-import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieClusteringConfig;
 import org.apache.hudi.hive.MultiPartKeysValueExtractor;
 import org.apache.hudi.utilities.config.HoodieStreamerConfig;
@@ -443,7 +442,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     List<String> configs = new ArrayList<>();
     configs.add(String.format("%s=%d", SourceTestConfig.MAX_UNIQUE_RECORDS_PROP.key(), totalRecords));
     if (nonEmpty(autoClean)) {
-      configs.add(String.format("%s=%s", HoodieCleanConfig.AUTO_CLEAN.key(), autoClean));
+      configs.add(String.format("%s=%s", "hoodie.clean.automatic", autoClean));
     }
     if (nonEmpty(inlineCluster)) {
       configs.add(String.format("%s=%s", HoodieClusteringConfig.INLINE_CLUSTERING.key(), inlineCluster));

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -705,7 +705,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     }
     cfg.tableType = tableType.name();
     cfg.configs.add(String.format("%s=%d", SourceTestConfig.MAX_UNIQUE_RECORDS_PROP.key(), totalRecords));
-    cfg.configs.add(String.format("%s=false", HoodieCleanConfig.AUTO_CLEAN.key()));
+    cfg.configs.add(String.format("%s=false", "hoodie.clean.automatic"));
     HoodieDeltaStreamer ds = new HoodieDeltaStreamer(cfg, jsc);
     deltaStreamerTestRunner(ds, cfg, (r) -> {
       if (tableType.equals(HoodieTableType.MERGE_ON_READ)) {
@@ -941,13 +941,13 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     configs.add(String.format("%s=%s", HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "1"));
     configs.add(String.format("%s=%s", HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "4"));
     configs.add(String.format("%s=%s", HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "5"));
-    configs.add(String.format("%s=%s", HoodieCleanConfig.ASYNC_CLEAN.key(), asyncClean));
+    configs.add(String.format("%s=%s", "hoodie.clean.async", asyncClean));
     configs.add(String.format("%s=%s", HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key(), "1"));
     configs.add(String.format("%s=%s", HoodieWriteConfig.MARKERS_TYPE.key(), "DIRECT"));
     if (asyncClean) {
       configs.add(String.format("%s=%s", HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(),
           WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name()));
-      configs.add(String.format("%s=%s", HoodieCleanConfig.FAILED_WRITES_CLEANER_POLICY.key(),
+      configs.add(String.format("%s=%s", "hoodie.cleaner.incremental.mode",
           HoodieFailedWritesCleaningPolicy.LAZY.name()));
       configs.add(String.format("%s=%s", HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key(),
           InProcessLockProvider.class.getName()));
@@ -993,7 +993,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     configs.add(String.format("%s=%s", HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key(), InProcessLockProvider.class.getCanonicalName()));
     configs.add(String.format("%s=%s", LockConfiguration.LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY, "3000"));
     configs.add(String.format("%s=%s", HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name()));
-    configs.add(String.format("%s=%s", HoodieCleanConfig.FAILED_WRITES_CLEANER_POLICY.key(), HoodieFailedWritesCleaningPolicy.LAZY.name()));
+    configs.add(String.format("%s=%s", "hoodie.cleaner.incremental.mode", HoodieFailedWritesCleaningPolicy.LAZY.name()));
     return configs;
   }
 
@@ -1676,7 +1676,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     cfg2.filterDupes = false;
     cfg2.sourceLimit = 2000;
     cfg2.operation = WriteOperationType.UPSERT;
-    cfg2.configs.add(String.format("%s=false", HoodieCleanConfig.AUTO_CLEAN.key()));
+    cfg2.configs.add(String.format("%s=false", "hoodie.clean.automatic"));
     HoodieDeltaStreamer ds2 = new HoodieDeltaStreamer(cfg2, jsc);
     ds2.sync();
     mClient = HoodieTableMetaClient.builder().setConf(jsc.hadoopConfiguration()).setBasePath(tableBasePath).setLoadActiveTimelineOnLoad(true).build();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
@@ -28,7 +28,6 @@ import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.FileIOUtils;
-import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.execution.bulkinsert.BulkInsertSortMode;
@@ -106,7 +105,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
         propsFilePath, Collections.singletonList(TestHoodieDeltaStreamer.TripsWithDistanceTransformer.class.getName()));
     prepJobConfig.continuousMode = true;
     prepJobConfig.configs.add(String.format("%s=%d", SourceTestConfig.MAX_UNIQUE_RECORDS_PROP.key(), totalRecords));
-    prepJobConfig.configs.add(String.format("%s=false", HoodieCleanConfig.AUTO_CLEAN.key()));
+    prepJobConfig.configs.add(String.format("%s=false", "hoodie.clean.automatic"));
     // if we don't disable small file handling, log files may never get created and hence for MOR, compaction may not kick in.
     if (tableType == HoodieTableType.MERGE_ON_READ) {
       prepJobConfig.configs.add(String.format("%s=3", HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key()));
@@ -131,7 +130,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
         propsFilePath, Collections.singletonList(TestHoodieDeltaStreamer.TripsWithDistanceTransformer.class.getName()));
     cfgIngestionJob.continuousMode = true;
     cfgIngestionJob.configs.add(String.format("%s=%d", SourceTestConfig.MAX_UNIQUE_RECORDS_PROP.key(), totalRecords));
-    cfgIngestionJob.configs.add(String.format("%s=false", HoodieCleanConfig.AUTO_CLEAN.key()));
+    cfgIngestionJob.configs.add(String.format("%s=false", "hoodie.clean.automatic"));
 
     // create a backfill job
     HoodieDeltaStreamer.Config cfgBackfillJob = getDeltaStreamerConfig(tableBasePath, tableType.name(), WriteOperationType.UPSERT,
@@ -143,7 +142,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
         .fromBytes(timeline.getInstantDetails(timeline.firstInstant().get()).get(), HoodieCommitMetadata.class);
     cfgBackfillJob.checkpoint = commitMetadata.getMetadata(CHECKPOINT_KEY);
     cfgBackfillJob.configs.add(String.format("%s=%d", SourceTestConfig.MAX_UNIQUE_RECORDS_PROP.key(), totalRecords));
-    cfgBackfillJob.configs.add(String.format("%s=false", HoodieCleanConfig.AUTO_CLEAN.key()));
+    cfgBackfillJob.configs.add(String.format("%s=false", "hoodie.clean.automatic"));
     HoodieDeltaStreamer backfillJob = new HoodieDeltaStreamer(cfgBackfillJob, jsc);
 
     // re-init ingestion job to start sync service
@@ -173,7 +172,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
         propsFilePath, Collections.singletonList(TestHoodieDeltaStreamer.TripsWithDistanceTransformer.class.getName()));
     prepJobConfig.continuousMode = true;
     prepJobConfig.configs.add(String.format("%s=%d", SourceTestConfig.MAX_UNIQUE_RECORDS_PROP.key(), totalRecords));
-    prepJobConfig.configs.add(String.format("%s=false", HoodieCleanConfig.AUTO_CLEAN.key()));
+    prepJobConfig.configs.add(String.format("%s=false", "hoodie.clean.automatic"));
     HoodieDeltaStreamer prepJob = new HoodieDeltaStreamer(prepJobConfig, jsc);
 
     // Prepare base dataset with some commits
@@ -204,13 +203,13 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
         .fromBytes(timeline.getInstantDetails(timeline.firstInstant().get()).get(), HoodieCommitMetadata.class);
     cfgBackfillJob2.checkpoint = commitMetadata.getMetadata(CHECKPOINT_KEY);
     cfgBackfillJob2.configs.add(String.format("%s=%d", SourceTestConfig.MAX_UNIQUE_RECORDS_PROP.key(), totalRecords));
-    cfgBackfillJob2.configs.add(String.format("%s=false", HoodieCleanConfig.AUTO_CLEAN.key()));
+    cfgBackfillJob2.configs.add(String.format("%s=false", "hoodie.clean.automatic"));
 
     HoodieDeltaStreamer.Config cfgIngestionJob2 = getDeltaStreamerConfig(tableBasePath, tableType.name(), WriteOperationType.UPSERT,
         propsFilePath, Collections.singletonList(TestHoodieDeltaStreamer.TestIdentityTransformer.class.getName()));
     cfgIngestionJob2.continuousMode = true;
     cfgIngestionJob2.configs.add(String.format("%s=%d", SourceTestConfig.MAX_UNIQUE_RECORDS_PROP.key(), totalRecords));
-    cfgIngestionJob2.configs.add(String.format("%s=false", HoodieCleanConfig.AUTO_CLEAN.key()));
+    cfgIngestionJob2.configs.add(String.format("%s=false", "hoodie.clean.automatic"));
     // re-init ingestion job
     HoodieDeltaStreamer ingestionJob3 = new HoodieDeltaStreamer(cfgIngestionJob2, jsc);
     // re-init backfill job
@@ -241,7 +240,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
         propsFilePath, Collections.singletonList(TestHoodieDeltaStreamer.TripsWithDistanceTransformer.class.getName()));
     prepJobConfig.continuousMode = true;
     prepJobConfig.configs.add(String.format("%s=%d", SourceTestConfig.MAX_UNIQUE_RECORDS_PROP.key(), totalRecords));
-    prepJobConfig.configs.add(String.format("%s=false", HoodieCleanConfig.AUTO_CLEAN.key()));
+    prepJobConfig.configs.add(String.format("%s=false", "hoodie.clean.automatic"));
     HoodieDeltaStreamer prepJob = new HoodieDeltaStreamer(prepJobConfig, jsc);
 
     // Prepare base dataset with some commits
@@ -277,7 +276,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
     // Set checkpoint to the last successful position
     cfgBackfillJob.checkpoint = commitMetadataForLastInstant.getMetadata(CHECKPOINT_KEY);
     cfgBackfillJob.configs.add(String.format("%s=%d", SourceTestConfig.MAX_UNIQUE_RECORDS_PROP.key(), totalRecords));
-    cfgBackfillJob.configs.add(String.format("%s=false", HoodieCleanConfig.AUTO_CLEAN.key()));
+    cfgBackfillJob.configs.add(String.format("%s=false", "hoodie.clean.automatic"));
     HoodieDeltaStreamer backfillJob = new HoodieDeltaStreamer(cfgBackfillJob, jsc);
     backfillJob.sync();
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
@@ -306,7 +306,7 @@ class TestHoodieMultiTableServicesMain extends HoodieCommonTestHarness implement
     cfg.enableArchive = true;
     List<String> configs = new ArrayList<>();
     configs.add(String.format("%s=%s", HoodieCleanConfig.CLEANER_POLICY.key(), HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS));
-    configs.add(String.format("%s=%s", HoodieCleanConfig.AUTO_CLEAN.key(), "false"));
+    configs.add(String.format("%s=%s", "hoodie.clean.automatic", "false"));
     configs.add(String.format("%s=%s", HoodieCleanConfig.CLEANER_FILE_VERSIONS_RETAINED.key(), "1"));
     configs.add(String.format("%s=%s", HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "0"));
     cfg.configs = configs;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/TestHoodieClusteringJob.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/TestHoodieClusteringJob.java
@@ -160,7 +160,7 @@ public class TestHoodieClusteringJob extends HoodieOfflineJobTestBase {
     config.runSchedule = runSchedule;
     config.runningMode = runningMode;
     config.configs.add("hoodie.metadata.enable=false");
-    config.configs.add(String.format("%s=%s", HoodieCleanConfig.AUTO_CLEAN.key(), isAutoClean));
+    config.configs.add(String.format("%s=%s", "hoodie.clean.automatic", isAutoClean));
     config.configs.add(String.format("%s=%s", HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), 1));
     config.configs.add(String.format("%s=%s", HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), 1));
     return config;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/TestHoodieCompactorJob.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/TestHoodieCompactorJob.java
@@ -115,7 +115,7 @@ public class TestHoodieCompactorJob extends HoodieOfflineJobTestBase {
     config.runSchedule = runSchedule;
     config.runningMode = runningMode;
     config.configs.add("hoodie.metadata.enable=false");
-    config.configs.add(String.format("%s=%s", HoodieCleanConfig.AUTO_CLEAN.key(), isAutoClean));
+    config.configs.add(String.format("%s=%s", "hoodie.clean.automatic", isAutoClean));
     config.configs.add(String.format("%s=%s", HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), 1));
     config.configs.add(String.format("%s=%s", HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), 1));
     return config;


### PR DESCRIPTION
### Change Logs

MR for checking backward compatibility after configuration parameters renaming.

To check backward compatibility, it’s possible to changed all keys used as constants to the corresponding string representations in old naming style. But do it in tests only, and run CI.

The algorithm for check-only commit generation:
- prepare list of constants and corresponding string representation (`list-of-keys.txt`),
- use bash script (`check-compatibility-for-keys.sh`) to replace all using,
- remove unnecessary imports using `mvn checkstyle:check`,
- run CI in your fork.

For this MR `list-of-keys.txt` containing data in the form of `class|constant|old_name`:
```
HoodieCleanConfig|AUTO_CLEAN|hoodie.clean.automatic
HoodieCleanConfig|ASYNC_CLEAN|hoodie.clean.async
HoodieCleanConfig|CLEAN_TRIGGER_STRATEGY|hoodie.clean.trigger.strategy
HoodieCleanConfig|CLEAN_MAX_COMMITS|hoodie.clean.max.commits
HoodieCleanConfig|CLEANER_INCREMENTAL_MODE_ENABLE|hoodie.cleaner.incremental.mode
HoodieCleanConfig|FAILED_WRITES_CLEANER_POLICY|hoodie.cleaner.incremental.mode
HoodieCleanConfig|ALLOW_MULTIPLE_CLEANS|hoodie.clean.allow.multiple
FlinkOptions|CLEAN_ASYNC_ENABLED|clean.async.enabled
FlinkOptions|CLEAN_POLICY|clean.policy
FlinkOptions|CLEAN_RETAIN_COMMITS|clean.retain_commits
FlinkOptions|CLEAN_RETAIN_HOURS|clean.retain_hours
FlinkOptions|CLEAN_RETAIN_FILE_VERSIONS|clean.retain_file_versions
```

`check-compatibility-for-keys.sh` bash script:
```
#!/bin/bash

delimiter='|'

while IFS="${delimiter}" read -r class const key; do
  filelist=$(rg -l "${const}.key" . | grep "\/src\/test")
  echo -e "${filelist}" | xargs sed -i "s/${class}.${const}.key()/\"${key}\"/g"
  echo -e "${filelist}" | xargs sed -i "s/${class}.${const}.key/\"${key}\"/g"
  echo -e "${filelist}" | xargs sed -i "s/${const}.key()/\"${key}\"/g"
  echo -e "${filelist}" | xargs sed -i "s/${const}.key/\"${key}\"/g"
done

```
