### PR TITLE
[POC] Switch from `HoodieRecord` to Flink `Tuple2<Tuple2<BinaryStringData, BinaryStringData>, RowData>`

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -675,6 +675,13 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(ClientIds.INIT_CLIENT_ID)
       .withDescription("Unique identifier used to distinguish different writer pipelines for concurrent mode");
 
+  @AdvancedConfig
+  public static final ConfigOption<Boolean> WRITE_FAST_TO_PARQUET_BLOCKS = ConfigOptions
+      .key("write.fast.to.parquet.blocks")
+      .booleanType()
+      .defaultValue(false)
+      .withDescription("Optimized write of row data to MOR log files. Note, that Parquet data blocks should be used in log files.");
+
   // ------------------------------------------------------------------------
   //  Compaction Options
   // ------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunctionRowData.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunctionRowData.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.bucket;
+
+import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieOperation;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordLocation;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.util.Functions;
+import org.apache.hudi.common.util.hash.BucketIndexUtil;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.configuration.OptionsResolver;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.index.bucket.BucketIdentifier;
+import org.apache.hudi.sink.StreamWriteFunction;
+import org.apache.hudi.sink.utils.PayloadCreation;
+import org.apache.hudi.util.RowDataToAvroConverters;
+import org.apache.hudi.util.StreamerUtil;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A stream write function with simple bucket hash index.
+ *
+ * <p>The task holds a fresh new local index: {(partition + bucket number) &rarr fileId} mapping, this index
+ * is used for deciding whether the incoming records in an UPDATE or INSERT.
+ * The index is local because different partition paths have separate items in the index.
+ *
+ * @param <I> the input type
+ */
+public class BucketStreamWriteFunctionRowData<I> extends StreamWriteFunction<I> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BucketStreamWriteFunction.class);
+
+  private int parallelism;
+
+  private int bucketNum;
+
+  private String indexKeyFields;
+
+  private boolean isNonBlockingConcurrencyControl;
+
+  /**
+   * BucketID to file group mapping in each partition.
+   * Map(partition -> Map(bucketId, fileID)).
+   */
+  private Map<String, Map<Integer, String>> bucketIndex;
+
+  /**
+   * Incremental bucket index of the current checkpoint interval,
+   * it is needed because the bucket type('I' or 'U') should be decided based on the committed files view,
+   * all the records in one bucket should have the same bucket type.
+   */
+  private Set<String> incBucketIndex;
+
+  /**
+   * Functions for calculating the task partition to dispatch.
+   */
+  private Functions.Function2<String, Integer, Integer> partitionIndexFunc;
+
+
+  /**
+   * To prevent strings compare for each record, define this only during open()
+   */
+  private boolean isInsertOverwrite;
+
+  private RowType rowType;
+  private transient Schema avroSchema;
+  private transient RowDataToAvroConverters.RowDataToAvroConverter converter;
+  private transient PayloadCreation payloadCreation;
+
+  /**
+   * Constructs a BucketStreamWriteFunction.
+   *
+   * @param config The config options
+   */
+  public BucketStreamWriteFunctionRowData(Configuration config, RowType rowType) {
+    super(config);
+    this.rowType = rowType;
+  }
+
+  @Override
+  public void open(Configuration parameters) throws IOException {
+    super.open(parameters);
+    this.bucketNum = config.getInteger(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS);
+    this.indexKeyFields = OptionsResolver.getIndexKeyField(config);
+    this.isNonBlockingConcurrencyControl = OptionsResolver.isNonBlockingConcurrencyControl(config);
+    this.taskID = getRuntimeContext().getIndexOfThisSubtask();
+    this.parallelism = getRuntimeContext().getNumberOfParallelSubtasks();
+    this.bucketIndex = new HashMap<>();
+    this.incBucketIndex = new HashSet<>();
+    this.partitionIndexFunc = BucketIndexUtil.getPartitionIndexFunc(bucketNum, parallelism);
+    this.isInsertOverwrite = OptionsResolver.isInsertOverwrite(config);
+
+    this.avroSchema = StreamerUtil.getSourceSchema(this.config);
+    this.converter = RowDataToAvroConverters.createConverter(this.rowType, this.config.getBoolean(FlinkOptions.WRITE_UTC_TIMEZONE));
+    try {
+      this.payloadCreation = PayloadCreation.instance(config);
+    } catch (Exception ex) {
+      throw new HoodieException("Failed payload creation in BucketStreamWriteFunctionRowData", ex);
+    }
+  }
+
+  @Override
+  public void initializeState(FunctionInitializationContext context) throws Exception {
+    super.initializeState(context);
+  }
+
+  @Override
+  public void snapshotState() {
+    super.snapshotState();
+    this.incBucketIndex.clear();
+  }
+
+  @Override
+  public void processElement(I income, ProcessFunction<I, Object>.Context context, Collector<Object> collector) throws Exception {
+
+    Tuple2<StringData, StringData> metadata = ((Tuple2<Tuple, RowData>) income).getField(0);
+    String recordKey = metadata.getField(0).toString();
+    String partition = metadata.getField(1).toString();
+
+    RowData row = ((Tuple2<Tuple, RowData>) income).getField(1);
+    GenericRecord gr = (GenericRecord) this.converter.convert(this.avroSchema, row);
+    final HoodieKey hoodieKey = new HoodieKey(recordKey, partition);
+    HoodieRecordPayload payload = payloadCreation.createPayload(gr);
+    HoodieOperation operation = HoodieOperation.fromValue(row.getRowKind().toByteValue());
+    HoodieRecord record = new HoodieAvroRecord<>(hoodieKey, payload, operation);
+    final HoodieRecordLocation location;
+
+    // for insert overwrite operation skip the index loading
+    if (!isInsertOverwrite) {
+      bootstrapIndexIfNeed(partition);
+    }
+
+    Map<Integer, String> bucketToFileId = bucketIndex.computeIfAbsent(partition, p -> new HashMap<>());
+    final int bucketNum = BucketIdentifier.getBucketId(hoodieKey, indexKeyFields, this.bucketNum);
+    final String bucketId = partition + "/" + bucketNum;
+
+    if (incBucketIndex.contains(bucketId)) {
+      location = new HoodieRecordLocation("I", bucketToFileId.get(bucketNum));
+    } else if (bucketToFileId.containsKey(bucketNum)) {
+      location = new HoodieRecordLocation("U", bucketToFileId.get(bucketNum));
+    } else {
+      String newFileId = BucketIdentifier.newBucketFileIdPrefix(bucketNum, isNonBlockingConcurrencyControl);
+      location = new HoodieRecordLocation("I", newFileId);
+      bucketToFileId.put(bucketNum, newFileId);
+      incBucketIndex.add(bucketId);
+    }
+    record.unseal();
+    record.setCurrentLocation(location);
+    record.seal();
+    bufferRecord(record);
+  }
+
+  /**
+   * Determine whether the current fileID belongs to the current task.
+   * partitionIndex == this taskID belongs to this task.
+   */
+  public boolean isBucketToLoad(int bucketNumber, String partition) {
+    return this.partitionIndexFunc.apply(partition, bucketNumber) == taskID;
+  }
+
+  /**
+   * Get partition_bucket -> fileID mapping from the existing hudi table.
+   * This is a required operation for each restart to avoid having duplicate file ids for one bucket.
+   */
+  private void bootstrapIndexIfNeed(String partition) {
+    if (bucketIndex.containsKey(partition)) {
+      return;
+    }
+    LOG.info("Loading Hoodie Table {}, with path {}/{}", this.metaClient.getTableConfig().getTableName(),
+        this.metaClient.getBasePath(), partition);
+
+    // Load existing fileID belongs to this task
+    Map<Integer, String> bucketToFileIDMap = new HashMap<>();
+    this.writeClient.getHoodieTable().getHoodieView().getLatestFileSlices(partition).forEach(fileSlice -> {
+      String fileId = fileSlice.getFileId();
+      int bucketNumber = BucketIdentifier.bucketIdFromFileId(fileId);
+      if (isBucketToLoad(bucketNumber, partition)) {
+        LOG.info(String.format("Should load this partition bucket %s with fileId %s", bucketNumber, fileId));
+        // Validate that one bucketId has only ONE fileId
+        if (bucketToFileIDMap.containsKey(bucketNumber)) {
+          throw new RuntimeException(String.format("Duplicate fileId %s from bucket %s of partition %s found "
+              + "during the BucketStreamWriteFunction index bootstrap.", fileId, bucketNumber, partition));
+        } else {
+          LOG.info(String.format("Adding fileId %s to the bucket %s of partition %s.", fileId, bucketNumber, partition));
+          bucketToFileIDMap.put(bucketNumber, fileId);
+        }
+      }
+    });
+    bucketIndex.put(partition, bucketToFileIDMap);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteOperatorRowData.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteOperatorRowData.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.bucket;
+
+import org.apache.hudi.configuration.OptionsResolver;
+import org.apache.hudi.exception.HoodieNotSupportedException;
+import org.apache.hudi.sink.common.AbstractWriteOperator;
+import org.apache.hudi.sink.common.WriteOperatorFactory;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Operator for {@link BucketStreamWriteFunctionRowData}.
+ *
+ * @param <I> The input type
+ */
+public class BucketStreamWriteOperatorRowData<I> extends AbstractWriteOperator<I> {
+
+  public BucketStreamWriteOperatorRowData(Configuration conf, RowType rowType) {
+    super(new BucketStreamWriteFunctionRowData<>(conf, rowType));
+  }
+
+  public static <I> WriteOperatorFactory<I> getFactory(Configuration conf, RowType rowType) throws HoodieNotSupportedException {
+    // add support of ConsistentBucketStreamWriteFunctionRowData
+    if (!OptionsResolver.isConsistentHashingBucketIndexType(conf)) {
+      return WriteOperatorFactory.instance(conf, new BucketStreamWriteOperatorRowData<>(conf, rowType));
+    } else {
+      throw new HoodieNotSupportedException("Consistent bucket is not supported yet");
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexPartitionerRowData.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexPartitionerRowData.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner;
+
+import org.apache.hudi.common.util.Functions;
+import org.apache.hudi.common.util.hash.BucketIndexUtil;
+import org.apache.hudi.index.bucket.BucketIdentifier;
+
+import org.apache.flink.api.common.functions.Partitioner;
+import org.apache.flink.api.java.tuple.Tuple;
+
+/**
+ * Bucket index input partitioner.
+ * The fields to hash can be a subset of the primary key fields.
+ *
+ * @param <T> The type of obj to hash
+ */
+public class BucketIndexPartitionerRowData<T extends Tuple> implements Partitioner<T> {
+
+  private final int bucketNum;
+  private final String indexKeyFields;
+
+  private Functions.Function2<String, Integer, Integer> partitionIndexFunc;
+
+  public BucketIndexPartitionerRowData(int bucketNum, String indexKeyFields) {
+    this.bucketNum = bucketNum;
+    this.indexKeyFields = indexKeyFields;
+  }
+
+  @Override
+  public int partition(T metadata, int numPartitions) {
+    if (this.partitionIndexFunc == null) {
+      this.partitionIndexFunc = BucketIndexUtil.getPartitionIndexFunc(bucketNum, numPartitions);
+    }
+    int curBucket = BucketIdentifier.getBucketId(metadata.getField(0).toString(), indexKeyFields, bucketNum);
+    return this.partitionIndexFunc.apply(metadata.getField(1).toString(), curBucket);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataEnrichFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataEnrichFunction.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.transform;
+
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.keygen.KeyGenerator;
+import org.apache.hudi.keygen.factory.HoodieAvroKeyGeneratorFactory;
+import org.apache.hudi.util.RowDataToAvroConverters;
+import org.apache.hudi.util.StreamerUtil;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Function that transforms RowData to GenericRowData.
+ */
+public class RowDataEnrichFunction<I extends RowData, O extends Tuple>
+    extends RichMapFunction<I, O> {
+  /**
+   * Row type of the input.
+   */
+  private final RowType rowType;
+
+  /**
+   * Avro schema of the input.
+   */
+  private transient Schema avroSchema;
+
+  /**
+   * RowData to Avro record converter.
+   */
+  private transient RowDataToAvroConverters.RowDataToAvroConverter converter;
+
+  /**
+   * HoodieKey generator.
+   */
+  private transient KeyGenerator keyGenerator;
+
+  /**
+   * Config options.
+   */
+  private final Configuration config;
+
+  public RowDataEnrichFunction(RowType rowType, Configuration config) {
+    this.rowType = rowType;
+    this.config = config;
+  }
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    super.open(parameters);
+    this.avroSchema = StreamerUtil.getSourceSchema(this.config);
+    this.converter = RowDataToAvroConverters.createConverter(this.rowType, this.config.getBoolean(FlinkOptions.WRITE_UTC_TIMEZONE));
+    this.keyGenerator = HoodieAvroKeyGeneratorFactory.createKeyGenerator(StreamerUtil.flinkConf2TypedProperties(this.config));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public O map(I i) throws Exception {
+    return (O) enrichRowData(i);
+  }
+
+  private Tuple2<Tuple2<BinaryStringData, BinaryStringData>, RowData> enrichRowData(I record) {
+    GenericRecord gr = (GenericRecord) this.converter.convert(this.avroSchema, record);
+    final HoodieKey hoodieKey = keyGenerator.getKey(gr);
+    // metadata tuple (recordKey, partitionPath)
+    Tuple2<BinaryStringData, BinaryStringData> metaData = new Tuple2<>(new BinaryStringData(hoodieKey.getRecordKey()),
+        new BinaryStringData(hoodieKey.getPartitionPath()));
+    return new Tuple2<>(metaData, record);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataEnrichFunctionWithRateLimit.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataEnrichFunctionWithRateLimit.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.transform;
+
+import org.apache.hudi.common.util.RateLimiter;
+import org.apache.hudi.configuration.FlinkOptions;
+
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Function that transforms RowData to GenericRowData with RateLimit.
+ */
+public class RowDataEnrichFunctionWithRateLimit<I extends RowData, O extends Tuple>
+    extends RowDataEnrichFunction<I, O> {
+  /**
+   * Total rate limit per second for this job.
+   */
+  private final double totalLimit;
+
+  /**
+   * Rate limit per second for per task.
+   */
+  private transient RateLimiter rateLimiter;
+
+  public RowDataEnrichFunctionWithRateLimit(RowType rowType, Configuration config) {
+    super(rowType, config);
+    this.totalLimit = config.getLong(FlinkOptions.WRITE_RATE_LIMIT);
+  }
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    super.open(parameters);
+    this.rateLimiter =
+        RateLimiter.create((int) totalLimit / getRuntimeContext().getNumberOfParallelSubtasks(), TimeUnit.SECONDS);
+  }
+
+  @Override
+  public O map(I i) throws Exception {
+    rateLimiter.acquire(1);
+    return super.map(i);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataEnrichFunctions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataEnrichFunctions.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.transform;
+
+import org.apache.hudi.configuration.FlinkOptions;
+
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Utilities for {@link RowDataToHoodieFunction}.
+ */
+public abstract class RowDataEnrichFunctions {
+  private RowDataEnrichFunctions() {
+  }
+
+  /**
+   * Creates a {@link RowDataEnrichFunctions} instance based on the given configuration.
+   */
+  @SuppressWarnings("rawtypes")
+  public static RowDataEnrichFunction<RowData, Tuple> create(RowType rowType, Configuration conf) {
+    if (conf.getLong(FlinkOptions.WRITE_RATE_LIMIT) > 0) {
+      return new RowDataEnrichFunctionWithRateLimit<>(rowType, conf);
+    } else {
+      return new RowDataEnrichFunction<>(rowType, conf);
+    }
+  }
+}


### PR DESCRIPTION
MR for illustration purpose as addition to the letter:
https://lists.apache.org/thread/3dtxo955tb8xpdht4cj9524zqnxcvkhx


### Description
Currently we convert Flink `RowData` to `HoodieRecord` first, and then `HoodieRecord` is serialized and deserialized using Kryo.
![flame graph - 01 reference ser](https://github.com/user-attachments/assets/13aeb2af-20d6-4543-8586-6bf84f9800bc)
![flame graph - 02 reference de](https://github.com/user-attachments/assets/2c4778eb-e4bd-43ed-86d7-a602deef0e72)

But this serde is really expensive.

### Proof of concept
I've tried to use `Tuple2<Tuple2<BinaryStringData, BinaryStringData>, RowData>` to check results, and got significant decrease in serde costs:
![flame graph - 03 tuple poc ser](https://github.com/user-attachments/assets/23304851-fd7b-4ec2-90de-d74bb3c42395)
![flame graph - 04 tuple poc de](https://github.com/user-attachments/assets/764fde74-ba37-45b6-a9df-f0b2f20788bb)

CPU samples comparison:
|                  | current with Kryo | POC version |
| ----------- | -------- | ------------- |
| serialize     | 33 900 | 10 100 |
| deserialize | 69 400 | 10 500 |

### Quick overview
I used `Tuple2<Tuple2<BinaryStringData, BinaryStringData>, RowData>` to save initial income record as `RowData` and pass `recordKey` and `partition` from first operator as `BinaryStringData`. This is needed to support different intermediate operators and hashing procedures:
![DataStream for HoodieTableSink](https://github.com/user-attachments/assets/7cfed4b3-55b8-4510-8465-4bcde7a50e87)

### Scenario
I've made profiling by writing 60 mln of rows with duplications (20 mln unique rows) to Hudi MOR table by upsert. Simple bucket index was used, number of buckets was equal to number of writers, and was equal to 8.

Flink operators with current Kryo serde:
![operators - 01 reference](https://github.com/user-attachments/assets/277bfc8e-6b7e-48ba-99e2-3c2a731bd905)

And in my POC:
![operators - 02 tuple poc](https://github.com/user-attachments/assets/c5cae291-1ced-4501-bbc6-679596eb446f)

After switch amount of data passed between first 2 operators decreased from 19.4 GB to 13.1 GB (32.5%), and total processing time decreased from 247 s to 208 s (15.8%), which is really significant.


### Result comparison table
|                                         | current with Kryo | POC version | Optimization |
| --------------------------- | ------------------ | -------------- | -------------- |
| CPU samples, serialize     | 33 900                 | 10 100          | **70.2%**      |
| CPU samples, deserialize | 69 400                 | 10 500          | **84.5%**      |
| **Data passed, GB**        | **19.4**               | **13.1**         | **32.5%**     |
| **Total time, s**               | **247**                | **208**         | **15.6%**     |


