### PR TITLE
Dsv2 poc

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/spark/sql/hudi/v2/PartialLimitPushDown.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/spark/sql/hudi/v2/PartialLimitPushDown.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2;
+
+import org.apache.spark.sql.connector.read.SupportsPushDownLimit;
+
+/**
+ * Extension of {@link SupportsPushDownLimit} that marks limit pushdown as partial.
+ *
+ * Spark 3.4+ added {@code isPartiallyPushed()} as a default method (returning false).
+ * Spark 3.3 does not have this method. By providing the default here in a Java interface,
+ * we avoid the Scala {@code override} keyword issue: Java default methods don't require
+ * {@code @Override}, so this compiles against both Spark 3.3 (new method) and 3.4+ (override).
+ *
+ * When {@code isPartiallyPushed()} returns true, Spark adds a final LocalLimit on top of the
+ * scan, which is necessary because Hudi's limit pushdown is best-effort (per-partition).
+ */
+public interface PartialLimitPushDown extends SupportsPushDownLimit {
+  default boolean isPartiallyPushed() {
+    return true;
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/resources/META-INF/services/org.apache.spark.sql.connector.catalog.TableProvider
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/resources/META-INF/services/org.apache.spark.sql.connector.catalog.TableProvider
@@ -16,6 +16,4 @@
 # limitations under the License.
 
 
-org.apache.hudi.BaseDefaultSource
-org.apache.spark.sql.execution.datasources.parquet.LegacyHoodieParquetFileFormat
 org.apache.spark.sql.hudi.v2.HoodieDataSourceV2

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -311,6 +311,14 @@ object DataSourceReadOptions {
       " for parsing partition values from partition path. When this config is enabled, it uses" +
       " PartitionValueExtractor class value stored in the hoodie.properties file.")
 
+  val USE_V2_READ: ConfigProperty[String] = ConfigProperty
+    .key("hoodie.datasource.read.use.v2")
+    .defaultValue("false")
+    .markAdvanced()
+    .sinceVersion("1.3.0")
+    .withDocumentation("When enabled, SQL/catalog queries use the DSv2 read path (HoodieSparkV2Table) " +
+      "instead of the default DSv1 path. The DataFrame API can also use format(\"hudi_v2\") directly.")
+
   /** @deprecated Use {@link QUERY_TYPE} and its methods instead */
   @Deprecated
   val QUERY_TYPE_OPT_KEY = QUERY_TYPE.key()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSparkBaseAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSparkBaseAnalysis.scala
@@ -39,6 +39,7 @@ import org.apache.spark.sql.hudi.analysis.HoodieSparkBaseAnalysis.{HoodieV1OrV2T
 import org.apache.spark.sql.hudi.catalog.HoodieInternalV2Table
 import org.apache.spark.sql.hudi.command.{AlterHoodieTableDropPartitionCommand, ShowHoodieTablePartitionsCommand, TruncateHoodieTableCommand}
 import org.apache.spark.sql.hudi.command.exception.HoodieAnalysisException
+import org.apache.spark.sql.hudi.v2.HoodieSparkV2Table
 import org.apache.spark.sql.types.{ArrayType, DecimalType, DoubleType, FloatType, IntegerType, LongType}
 
 /**
@@ -431,6 +432,7 @@ object HoodieSparkBaseAnalysis extends SparkAdapterSupport {
     def unapply(table: Table): Option[CatalogTable] = table match {
       case V1Table(catalogTable) if sparkAdapter.isHoodieTable(catalogTable) => Some(catalogTable)
       case v2: HoodieInternalV2Table => v2.catalogTable
+      case v2: HoodieSparkV2Table => v2.catalogTable
       case _ => None
     }
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSparkBaseAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSparkBaseAnalysis.scala
@@ -43,16 +43,6 @@ import org.apache.spark.sql.hudi.v2.HoodieSparkV2Table
 import org.apache.spark.sql.types.{ArrayType, DecimalType, DoubleType, FloatType, IntegerType, LongType}
 
 /**
- * NOTE: PLEASE READ CAREFULLY
- *
- * Since Hudi relations don't currently implement DS V2 Read API, we have to fallback to V1 here.
- * Such fallback will have considerable performance impact, therefore it's only performed in cases
- * where V2 API have to be used. Currently only such use-case is using of Schema Evolution feature
- *
- * Check out HUDI-4178 for more details
- */
-
-/**
  * Rule for resolve hoodie's extended syntax or rewrite some logical plan.
  */
 case class ResolveReferences(spark: SparkSession) extends Rule[LogicalPlan]

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieCatalog.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieCatalog.scala
@@ -143,13 +143,6 @@ class HoodieCatalog extends DelegatingCatalogExtension
           DataSourceReadOptions.USE_V2_READ.defaultValue).toBoolean
         val schemaEvolutionEnabled = ProvidesHoodieConfig.isSchemaEvolutionEnabled(spark)
 
-        // NOTE: PLEASE READ CAREFULLY
-        //
-        // Since Hudi relations don't currently implement DS V2 Read API, we by default fallback to V1 here.
-        // Such fallback will have considerable performance impact, therefore it's only performed in cases
-        // where V2 API have to be used. Currently only such use-case is using of Schema Evolution feature
-        //
-        // Check out HUDI-4178 for more details
         if (v2ReadEnabled) {
           HoodieSparkV2Table(
             spark = spark,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieCatalog.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieCatalog.scala
@@ -19,7 +19,7 @@
 
 package org.apache.spark.sql.hudi.catalog
 
-import org.apache.hudi.{DataSourceWriteOptions, SparkAdapterSupport}
+import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, SparkAdapterSupport}
 import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.table.HoodieTableMetaClient
@@ -47,6 +47,7 @@ import org.apache.spark.sql.hudi.analysis.HoodieSparkBaseAnalysis.HoodieV1OrV2Ta
 import org.apache.spark.sql.hudi.catalog.HoodieCatalog.{buildPartitionTransforms, isTablePartitioned}
 import org.apache.spark.sql.hudi.command._
 import org.apache.spark.sql.hudi.command.exception.HoodieAnalysisException
+import org.apache.spark.sql.hudi.v2.HoodieSparkV2Table
 import org.apache.spark.sql.types.{StructField, StructType}
 
 import java.net.URI
@@ -137,6 +138,9 @@ class HoodieCatalog extends DelegatingCatalogExtension
           catalogTable = Some(catalogTable),
           tableIdentifier = Some(ident.toString))
 
+        val v2ReadEnabled = spark.sessionState.conf.getConfString(
+          DataSourceReadOptions.USE_V2_READ.key,
+          DataSourceReadOptions.USE_V2_READ.defaultValue).toBoolean
         val schemaEvolutionEnabled = ProvidesHoodieConfig.isSchemaEvolutionEnabled(spark)
 
         // NOTE: PLEASE READ CAREFULLY
@@ -146,7 +150,12 @@ class HoodieCatalog extends DelegatingCatalogExtension
         // where V2 API have to be used. Currently only such use-case is using of Schema Evolution feature
         //
         // Check out HUDI-4178 for more details
-        if (schemaEvolutionEnabled) {
+        if (v2ReadEnabled) {
+          HoodieSparkV2Table(
+            spark = spark,
+            path = catalogTable.location.toString,
+            catalogTable = Some(catalogTable))
+        } else if (schemaEvolutionEnabled) {
           v2Table
         } else {
           v2Table.v1TableWrapper

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieInternalV2Table.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieInternalV2Table.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.hudi.catalog
 
+import org.apache.hudi.{HoodieSchemaConversionUtils, HoodieSparkSqlWriter}
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 
@@ -34,7 +35,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import java.util
 
-import scala.collection.JavaConverters.{mapAsJavaMapConverter, setAsJavaSetConverter}
+import scala.collection.JavaConverters.{mapAsJavaMapConverter, mapAsScalaMapConverter, setAsJavaSetConverter}
 
 case class HoodieInternalV2Table(spark: SparkSession,
                                  path: String,
@@ -87,9 +88,9 @@ case class HoodieInternalV2Table(spark: SparkSession,
 
 }
 
-private class HoodieV1WriteBuilder(writeOptions: CaseInsensitiveStringMap,
-                                   hoodieCatalogTable: HoodieCatalogTable,
-                                   spark: SparkSession)
+private[hudi] class HoodieV1WriteBuilder(writeOptions: CaseInsensitiveStringMap,
+                                         hoodieCatalogTable: HoodieCatalogTable,
+                                         spark: SparkSession)
   extends SupportsTruncate with SupportsOverwrite with ProvidesHoodieConfig {
 
   private var overwriteTable = false
@@ -115,11 +116,41 @@ private class HoodieV1WriteBuilder(writeOptions: CaseInsensitiveStringMap,
             SaveMode.Append
           }
 
-          data.write.format("org.apache.hudi")
-            .mode(mode)
-            .options(buildHoodieConfig(hoodieCatalogTable) ++
-              buildHoodieInsertConfig(hoodieCatalogTable, spark, overwritePartition, overwriteTable, Map.empty, Map.empty))
-            .save()
+          val writeOptsMap = writeOptions.asCaseSensitiveMap().asScala.toMap
+          val config = buildHoodieConfig(hoodieCatalogTable) ++
+            buildHoodieInsertConfig(hoodieCatalogTable, spark,
+              overwritePartition, overwriteTable, Map.empty, writeOptsMap) ++
+            writeOptsMap
+
+          // The V2-to-V1 fallback may receive a DataFrame with generic column names
+          // (e.g., col1, col2 from VALUES clause) and uncast types (e.g., DECIMAL literals
+          // for DOUBLE columns). Rename and cast columns to match the table's user schema.
+          val userSchema = hoodieCatalogTable.tableSchemaWithoutMetaFields
+          val alignedData = if (data.schema == userSchema) {
+            data
+          } else if (data.columns.length == userSchema.length) {
+            val columns = data.schema.fields.zip(userSchema.fields).map {
+              case (srcField, tgtField) =>
+                data.col(srcField.name).cast(tgtField.dataType).as(tgtField.name)
+            }
+            data.select(columns: _*)
+          } else {
+            data
+          }
+
+          // Pass the catalog schema so the V1 writer can properly reconcile the
+          // incoming schema with the full table schema (including meta-fields).
+          val (structName, namespace) =
+            HoodieSchemaConversionUtils.getRecordNameAndNamespace(hoodieCatalogTable.tableName)
+          val catalogSchema = HoodieSchemaConversionUtils
+            .convertStructTypeToHoodieSchema(hoodieCatalogTable.tableSchema, structName, namespace)
+
+          try {
+            HoodieSparkSqlWriter.write(spark.sqlContext, mode, config, alignedData,
+              schemaFromCatalog = Option(catalogSchema))
+          } finally {
+            HoodieSparkSqlWriter.cleanup()
+          }
         }
       }
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
@@ -18,14 +18,14 @@
 package org.apache.spark.sql.hudi.v2
 
 import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory, Scan}
+import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory, Scan, Statistics, SupportsReportStatistics}
 import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
 /**
- * Batch scan for CoW snapshot reads via DSv2.
+ * Batch scan for snapshot reads via DSv2 (COW).
  */
 class HoodieBatchScan(readSchema: StructType,
                       inputPartitions: Array[InputPartition],
@@ -33,7 +33,8 @@ class HoodieBatchScan(readSchema: StructType,
                       broadcastConf: Broadcast[SerializableConfiguration],
                       requiredDataSchema: StructType,
                       requiredPartitionSchema: StructType,
-                      pushedFilters: Array[Filter] = Array.empty) extends Scan with Batch {
+                      pushedFilters: Array[Filter] = Array.empty,
+                      pushedLimit: Option[Int] = None) extends Scan with Batch with SupportsReportStatistics {
 
   override def readSchema(): StructType = readSchema
 
@@ -43,7 +44,8 @@ class HoodieBatchScan(readSchema: StructType,
     } else {
       ", PushedFilters: []"
     }
-    s"HoodieBatchScan${readSchema.catalogString}$filtersStr"
+    val limitStr = pushedLimit.map(l => s", PushedLimit: $l").getOrElse("")
+    s"HoodieBatchScan${readSchema.catalogString}$filtersStr$limitStr"
   }
 
   override def toBatch: Batch = this
@@ -56,6 +58,14 @@ class HoodieBatchScan(readSchema: StructType,
       broadcastConf,
       readSchema,
       requiredDataSchema,
-      requiredPartitionSchema)
+      requiredPartitionSchema,
+      pushedLimit)
+  }
+
+  override def estimateStatistics(): Statistics = {
+    val totalSize = inputPartitions.collect {
+      case p: HoodieInputPartition => p.baseFileLength
+    }.sum
+    new HoodieStatistics(totalSize)
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory, Scan}
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Stub batch scan that returns an empty partition list.
+ * The read schema reflects any column pruning applied by the scan builder.
+ */
+class HoodieBatchScan(readSchema: StructType) extends Scan with Batch {
+
+  override def readSchema(): StructType = readSchema
+
+  override def toBatch: Batch = this
+
+  override def planInputPartitions(): Array[InputPartition] = Array.empty
+
+  override def createReaderFactory(): PartitionReaderFactory = new HoodiePartitionReaderFactory
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.hudi.v2
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory, Scan}
 import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
@@ -31,9 +32,19 @@ class HoodieBatchScan(readSchema: StructType,
                       broadcastReader: Broadcast[SparkColumnarFileReader],
                       broadcastConf: Broadcast[SerializableConfiguration],
                       requiredDataSchema: StructType,
-                      requiredPartitionSchema: StructType) extends Scan with Batch {
+                      requiredPartitionSchema: StructType,
+                      pushedFilters: Array[Filter] = Array.empty) extends Scan with Batch {
 
   override def readSchema(): StructType = readSchema
+
+  override def description(): String = {
+    val filtersStr = if (pushedFilters.nonEmpty) {
+      s", PushedFilters: [${pushedFilters.mkString(", ")}]"
+    } else {
+      ", PushedFilters: []"
+    }
+    s"HoodieBatchScan${readSchema.catalogString}$filtersStr"
+  }
 
   override def toBatch: Batch = this
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
@@ -17,20 +17,34 @@
 
 package org.apache.spark.sql.hudi.v2
 
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory, Scan}
+import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.SerializableConfiguration
 
 /**
- * Stub batch scan that returns an empty partition list.
- * The read schema reflects any column pruning applied by the scan builder.
+ * Batch scan for CoW snapshot reads via DSv2.
  */
-class HoodieBatchScan(readSchema: StructType) extends Scan with Batch {
+class HoodieBatchScan(readSchema: StructType,
+                      inputPartitions: Array[InputPartition],
+                      broadcastReader: Broadcast[SparkColumnarFileReader],
+                      broadcastConf: Broadcast[SerializableConfiguration],
+                      requiredDataSchema: StructType,
+                      requiredPartitionSchema: StructType) extends Scan with Batch {
 
   override def readSchema(): StructType = readSchema
 
   override def toBatch: Batch = this
 
-  override def planInputPartitions(): Array[InputPartition] = Array.empty
+  override def planInputPartitions(): Array[InputPartition] = inputPartitions
 
-  override def createReaderFactory(): PartitionReaderFactory = new HoodiePartitionReaderFactory
+  override def createReaderFactory(): PartitionReaderFactory = {
+    new HoodiePartitionReaderFactory(
+      broadcastReader,
+      broadcastConf,
+      readSchema,
+      requiredDataSchema,
+      requiredPartitionSchema)
+  }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieDataSourceV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieDataSourceV2.scala
@@ -56,7 +56,7 @@ class HoodieDataSourceV2 extends TableProvider with DataSourceRegister with Crea
       throw new HoodieException("'path' cannot be null, missing 'path' from table properties")
     }
 
-    HoodieSparkV2Table(SparkSession.active, path)
+    HoodieSparkV2Table(SparkSession.active, path, options = options)
   }
 
   override def createRelation(sqlContext: SQLContext,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieDataSourceV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieDataSourceV2.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.hudi.{DataSourceWriteOptions, HoodieEmptyRelation, HoodieSparkSqlWriter}
+import org.apache.hudi.exception.HoodieException
+
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession, SQLContext}
+import org.apache.spark.sql.connector.catalog.{Table, TableProvider}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, DataSourceRegister}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import java.util
+
+/**
+ * DSv2 data source for Hudi, registered with short name "hudi_v2".
+ *
+ * Activation via DataFrame API:
+ * - Read: `spark.read.format("hudi_v2").load(path)`
+ * - Write: `df.write.format("hudi_v2").save(path)`
+ *
+ * The SQL/Catalog path is handled by [[org.apache.spark.sql.hudi.catalog.HoodieCatalog.loadTable]].
+ *
+ * Write via DataFrame API is supported through [[CreatableRelationProvider]], which Spark uses
+ * as V1 fallback when the data source implements [[TableProvider]] + [[DataSourceRegister]].
+ */
+class HoodieDataSourceV2 extends TableProvider with DataSourceRegister with CreatableRelationProvider {
+
+  override def shortName(): String = "hudi_v2"
+
+  override def inferSchema(options: CaseInsensitiveStringMap): StructType = new StructType()
+
+  override def getTable(schema: StructType,
+                        partitioning: Array[Transform],
+                        properties: util.Map[String, String]): Table = {
+    val options = new CaseInsensitiveStringMap(properties)
+    val path = options.get("path")
+    if (path == null) {
+      throw new HoodieException("'path' cannot be null, missing 'path' from table properties")
+    }
+
+    HoodieSparkV2Table(SparkSession.active, path)
+  }
+
+  override def createRelation(sqlContext: SQLContext,
+                               mode: SaveMode,
+                               optParams: Map[String, String],
+                               df: DataFrame): BaseRelation = {
+    try {
+      if (optParams.get(DataSourceWriteOptions.OPERATION.key)
+        .contains(DataSourceWriteOptions.BOOTSTRAP_OPERATION_OPT_VAL)) {
+        HoodieSparkSqlWriter.bootstrap(sqlContext, mode, optParams, df)
+      } else {
+        val (success, _, _, _, _, _) = HoodieSparkSqlWriter.write(sqlContext, mode, optParams, df)
+        if (!success) {
+          throw new HoodieException("Failed to write to Hudi")
+        }
+      }
+    } finally {
+      HoodieSparkSqlWriter.cleanup()
+    }
+
+    new HoodieEmptyRelation(sqlContext, df.schema)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieInputPartition.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieInputPartition.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.spark.sql.connector.read.InputPartition
+
+/**
+ * Placeholder input partition for the DSv2 read path.
+ * Not used in the initial stub (PR1) since the scan returns an empty partition list.
+ */
+case class HoodieInputPartition(index: Int) extends InputPartition

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieInputPartition.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieInputPartition.scala
@@ -20,7 +20,15 @@ package org.apache.spark.sql.hudi.v2
 import org.apache.spark.sql.connector.read.InputPartition
 
 /**
- * Placeholder input partition for the DSv2 read path.
- * Not used in the initial stub (PR1) since the scan returns an empty partition list.
+ * Input partition for the DSv2 read path, representing a single base file to read.
+ *
+ * @param index           partition index
+ * @param baseFilePath    full path to the base (Parquet) file
+ * @param baseFileLength  file size in bytes
+ * @param partitionValues partition column values in Spark internal format (e.g. UTF8String),
+ *                        ordered to match the requiredPartitionSchema
  */
-case class HoodieInputPartition(index: Int) extends InputPartition
+case class HoodieInputPartition(index: Int,
+                                baseFilePath: String,
+                                baseFileLength: Long,
+                                partitionValues: Array[AnyRef]) extends InputPartition

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieLocalScan.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieLocalScan.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.read.{LocalScan, Scan}
+import org.apache.spark.sql.types.StructType
+
+/**
+ * A scan that returns pre-computed rows without reading any files.
+ * Used for fully pushed-down aggregates (e.g. COUNT(*) from column stats).
+ */
+class HoodieLocalScan(outputSchema: StructType, resultRows: Array[InternalRow])
+  extends Scan with LocalScan {
+
+  override def readSchema(): StructType = outputSchema
+
+  override def rows(): Array[InternalRow] = resultRows
+
+  override def description(): String = s"HoodieLocalScan[${resultRows.length} rows]"
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReader.scala
@@ -33,7 +33,7 @@ import org.apache.spark.util.SerializableConfiguration
 import java.io.Closeable
 
 /**
- * Partition reader that reads rows from a single CoW base file using [[SparkColumnarFileReader]].
+ * Partition reader that reads rows from a single COW base file using [[SparkColumnarFileReader]].
  */
 class
 
@@ -42,16 +42,20 @@ HoodiePartitionReader(partition: HoodieInputPartition,
                             broadcastConf: Broadcast[SerializableConfiguration],
                             readSchema: StructType,
                             requiredDataSchema: StructType,
-                            requiredPartitionSchema: StructType)
+                            requiredPartitionSchema: StructType,
+                            pushedLimit: Option[Int] = None)
   extends PartitionReader[InternalRow] with SparkAdapterSupport {
 
   private var rawIterator: Iterator[InternalRow] = _
   private val iter: Iterator[InternalRow] = createIterator()
   private var current: InternalRow = _
+  private var rowCount: Int = 0
 
   override def next(): Boolean = {
-    if (iter.hasNext) {
+    val limitReached = pushedLimit.exists(rowCount >= _)
+    if (!limitReached && iter.hasNext) {
       current = iter.next()
+      rowCount += 1
       true
     } else {
       false

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReader.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.read.PartitionReader
+
+/**
+ * Stub partition reader that always returns empty results.
+ * Will be replaced with real record reading in a subsequent PR.
+ */
+class HoodiePartitionReader extends PartitionReader[InternalRow] {
+
+  override def next(): Boolean = false
+
+  override def get(): InternalRow = {
+    throw new NoSuchElementException("HoodiePartitionReader stub has no rows")
+  }
+
+  override def close(): Unit = {}
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReader.scala
@@ -17,20 +17,73 @@
 
 package org.apache.spark.sql.hudi.v2
 
+import org.apache.hudi.SparkAdapterSupport
+import org.apache.hudi.common.util.{Option => HOption}
+import org.apache.hudi.storage.StoragePath
+import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration
+
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.sql.HoodieCatalystExpressionUtils
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.PartitionReader
+import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.SerializableConfiguration
+
+import java.io.Closeable
 
 /**
- * Stub partition reader that always returns empty results.
- * Will be replaced with real record reading in a subsequent PR.
+ * Partition reader that reads rows from a single CoW base file using [[SparkColumnarFileReader]].
  */
-class HoodiePartitionReader extends PartitionReader[InternalRow] {
+class
 
-  override def next(): Boolean = false
+HoodiePartitionReader(partition: HoodieInputPartition,
+                            broadcastReader: Broadcast[SparkColumnarFileReader],
+                            broadcastConf: Broadcast[SerializableConfiguration],
+                            readSchema: StructType,
+                            requiredDataSchema: StructType,
+                            requiredPartitionSchema: StructType)
+  extends PartitionReader[InternalRow] with SparkAdapterSupport {
 
-  override def get(): InternalRow = {
-    throw new NoSuchElementException("HoodiePartitionReader stub has no rows")
+  private var rawIterator: Iterator[InternalRow] = _
+  private val iter: Iterator[InternalRow] = createIterator()
+  private var current: InternalRow = _
+
+  override def next(): Boolean = {
+    if (iter.hasNext) {
+      current = iter.next()
+      true
+    } else {
+      false
+    }
   }
 
-  override def close(): Unit = {}
+  override def get(): InternalRow = current
+
+  override def close(): Unit = {
+    rawIterator match {
+      case c: Closeable => c.close()
+      case _ =>
+    }
+  }
+
+  private def createIterator(): Iterator[InternalRow] = {
+    val partValues = InternalRow.fromSeq(partition.partitionValues.toSeq)
+
+    val pFile = sparkAdapter.getSparkPartitionedFileUtils
+      .createPartitionedFile(partValues, new StoragePath(partition.baseFilePath), 0L, partition.baseFileLength)
+
+    val storageConf = new HadoopStorageConfiguration(broadcastConf.value.value)
+    rawIterator = broadcastReader.value.read(
+      pFile, requiredDataSchema, requiredPartitionSchema,
+      HOption.empty(), Seq.empty, storageConf)
+
+    val readerOutputSchema = StructType(requiredDataSchema.fields ++ requiredPartitionSchema.fields)
+    if (readerOutputSchema != readSchema) {
+      val projection = HoodieCatalystExpressionUtils.generateUnsafeProjection(readerOutputSchema, readSchema)
+      rawIterator.map(row => projection(row))
+    } else {
+      rawIterator
+    }
+  }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReaderFactory.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReaderFactory.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
+
+/**
+ * Stub factory that creates [[HoodiePartitionReader]] instances.
+ */
+class HoodiePartitionReaderFactory extends PartitionReaderFactory {
+
+  override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
+    new HoodiePartitionReader
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReaderFactory.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReaderFactory.scala
@@ -17,15 +17,29 @@
 
 package org.apache.spark.sql.hudi.v2
 
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
+import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.SerializableConfiguration
 
 /**
- * Stub factory that creates [[HoodiePartitionReader]] instances.
+ * Factory that creates [[HoodiePartitionReader]] instances for DSv2 CoW snapshot reads.
  */
-class HoodiePartitionReaderFactory extends PartitionReaderFactory {
+class HoodiePartitionReaderFactory(broadcastReader: Broadcast[SparkColumnarFileReader],
+                                   broadcastConf: Broadcast[SerializableConfiguration],
+                                   readSchema: StructType,
+                                   requiredDataSchema: StructType,
+                                   requiredPartitionSchema: StructType) extends PartitionReaderFactory {
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
-    new HoodiePartitionReader
+    new HoodiePartitionReader(
+      partition.asInstanceOf[HoodieInputPartition],
+      broadcastReader,
+      broadcastConf,
+      readSchema,
+      requiredDataSchema,
+      requiredPartitionSchema)
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReaderFactory.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReaderFactory.scala
@@ -25,21 +25,24 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
 /**
- * Factory that creates [[HoodiePartitionReader]] instances for DSv2 CoW snapshot reads.
+ * Factory that creates partition readers for COW snapshot reads.
  */
 class HoodiePartitionReaderFactory(broadcastReader: Broadcast[SparkColumnarFileReader],
                                    broadcastConf: Broadcast[SerializableConfiguration],
                                    readSchema: StructType,
                                    requiredDataSchema: StructType,
-                                   requiredPartitionSchema: StructType) extends PartitionReaderFactory {
+                                   requiredPartitionSchema: StructType,
+                                   pushedLimit: Option[Int] = None) extends PartitionReaderFactory {
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
+    val hoodiePart = partition.asInstanceOf[HoodieInputPartition]
     new HoodiePartitionReader(
-      partition.asInstanceOf[HoodieInputPartition],
+      hoodiePart,
       broadcastReader,
       broadcastConf,
       readSchema,
       requiredDataSchema,
-      requiredPartitionSchema)
+      requiredPartitionSchema,
+      pushedLimit)
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Stub scan builder that accepts column pruning and returns all filters as post-scan.
+ * Filter pushdown will be implemented in a subsequent PR.
+ */
+class HoodieScanBuilder(tableSchema: StructType) extends ScanBuilder
+  with SupportsPushDownFilters
+  with SupportsPushDownRequiredColumns {
+
+  private var requiredSchema: StructType = tableSchema
+  override def pushFilters(filters: Array[Filter]): Array[Filter] = {
+    // Stub: all filters are returned as post-scan (none pushed down)
+    filters
+  }
+
+  override def pushedFilters(): Array[Filter] = Array.empty
+
+  override def pruneColumns(requiredSchema: StructType): Unit = {
+    this.requiredSchema = requiredSchema
+  }
+
+  override def build(): Scan = new HoodieBatchScan(requiredSchema)
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
@@ -20,7 +20,10 @@ package org.apache.spark.sql.hudi.v2
 import org.apache.hudi.HoodieFileIndex
 import org.apache.hudi.SparkAdapterSupport
 import org.apache.hudi.common.table.HoodieTableMetaClient
+
+import org.apache.spark.sql.HoodieCatalystExpressionUtils
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.connector.read.{InputPartition, Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.sources.Filter
@@ -29,7 +32,7 @@ import org.apache.spark.util.SerializableConfiguration
 
 /**
  * Scan builder for DSv2 CoW snapshot reads.
- * Accepts column pruning; filter pushdown deferred to a later PR.
+ * Accepts column pruning and filter pushdown (partition pruning + data skipping).
  */
 class HoodieScanBuilder(spark: SparkSession,
                         metaClient: HoodieTableMetaClient,
@@ -40,22 +43,44 @@ class HoodieScanBuilder(spark: SparkSession,
   with SparkAdapterSupport {
 
   private var requiredSchema: StructType = tableSchema
+  private var _pushedFilters: Array[Filter] = Array.empty
+  private var partitionFilterExprs: Seq[Expression] = Seq.empty
+  private var dataFilterExprs: Seq[Expression] = Seq.empty
+
+  private lazy val fileIndex = HoodieFileIndex(spark, metaClient, None, options,
+    includeLogFiles = false, shouldEmbedFileSlices = false)
 
   override def pushFilters(filters: Array[Filter]): Array[Filter] = {
-    // All filters are returned as post-scan (none pushed down)
-    filters
+    val (pushed, postScan) = filters.partition { f =>
+      HoodieCatalystExpressionUtils.convertToCatalystExpression(f, tableSchema).isDefined
+    }
+
+    val expressions = pushed.flatMap(f =>
+      HoodieCatalystExpressionUtils.convertToCatalystExpression(f, tableSchema))
+
+    val (partFilters, datFilters) = HoodieCatalystExpressionUtils
+      .splitPartitionAndDataPredicates(spark, expressions, fileIndex.partitionSchema.fieldNames)
+
+    partitionFilterExprs = partFilters.toSeq
+    dataFilterExprs = datFilters.toSeq
+
+    _pushedFilters = pushed
+
+    // Data filters are only used for file-level skipping (via metadata indices),
+    // not for row-level filtering. Return them as postScan so Spark applies
+    // row-level filtering. Partition filters are fully handled by partition pruning.
+    val partFieldNames = fileIndex.partitionSchema.fieldNames.toSet
+    val dataFilterArr = pushed.filterNot(f => f.references.forall(partFieldNames.contains))
+    postScan ++ dataFilterArr
   }
 
-  override def pushedFilters(): Array[Filter] = Array.empty
+  override def pushedFilters(): Array[Filter] = _pushedFilters
 
   override def pruneColumns(requiredSchema: StructType): Unit = {
     this.requiredSchema = requiredSchema
   }
 
   override def build(): Scan = {
-    val fileIndex = HoodieFileIndex(spark, metaClient, None, options,
-      includeLogFiles = false, shouldEmbedFileSlices = false)
-
     val partFieldNames = fileIndex.partitionSchema.fieldNames.toSet
     val requiredDataSchema = StructType(requiredSchema.filterNot(f => partFieldNames.contains(f.name)))
     val requiredPartitionSchema = StructType(requiredSchema.filter(f => partFieldNames.contains(f.name)))
@@ -67,7 +92,7 @@ class HoodieScanBuilder(spark: SparkSession,
     val broadcastConf = spark.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
 
     val fullPartSchema = fileIndex.partitionSchema
-    val fileSlicesPerPartition = fileIndex.filterFileSlices(Seq.empty, Seq.empty)
+    val fileSlicesPerPartition = fileIndex.filterFileSlices(dataFilterExprs, partitionFilterExprs)
 
     val partitions = fileSlicesPerPartition.flatMap { case (partitionOpt, fileSlices) =>
       fileSlices.filter(fs => fs.getBaseFile.isPresent).map { fs =>
@@ -93,6 +118,7 @@ class HoodieScanBuilder(spark: SparkSession,
       broadcastReader,
       broadcastConf,
       requiredDataSchema,
-      requiredPartitionSchema)
+      requiredPartitionSchema,
+      _pushedFilters)
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, GenericInternalRow}
 import org.apache.spark.sql.connector.expressions.NamedReference
 import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, Count, CountStar, Max, Min}
-import org.apache.spark.sql.connector.read.{InputPartition, Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownFilters, SupportsPushDownLimit, SupportsPushDownRequiredColumns}
+import org.apache.spark.sql.connector.read.{InputPartition, Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructField, StructType}
@@ -50,7 +50,7 @@ class HoodieScanBuilder(spark: SparkSession,
                         options: Map[String, String]) extends ScanBuilder
   with SupportsPushDownFilters
   with SupportsPushDownRequiredColumns
-  with SupportsPushDownLimit
+  with PartialLimitPushDown
   with SupportsPushDownAggregates
   with SparkAdapterSupport {
 
@@ -101,8 +101,6 @@ class HoodieScanBuilder(spark: SparkSession,
     pushedLimit = Some(limit)
     true
   }
-
-  override def isPartiallyPushed(): Boolean = true
 
   override def pushAggregation(aggregation: Aggregation): Boolean = {
     if (aggregation.groupByExpressions().nonEmpty) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
@@ -17,22 +17,32 @@
 
 package org.apache.spark.sql.hudi.v2
 
-import org.apache.hudi.HoodieFileIndex
-import org.apache.hudi.SparkAdapterSupport
+import org.apache.hudi.{HoodieFileIndex, SparkAdapterSupport}
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.engine.HoodieLocalEngineContext
 import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.util.collection.Pair
+import org.apache.hudi.metadata.{HoodieBackedTableMetadata, MetadataPartitionType}
+import org.apache.hudi.stats.HoodieColumnRangeMetadata
 
 import org.apache.spark.sql.HoodieCatalystExpressionUtils
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.connector.read.{InputPartition, Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Expression, GenericInternalRow}
+import org.apache.spark.sql.connector.expressions.NamedReference
+import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, Count, CountStar, Max, Min}
+import org.apache.spark.sql.connector.read.{InputPartition, Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownFilters, SupportsPushDownLimit, SupportsPushDownRequiredColumns}
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructField, StructType}
+import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.SerializableConfiguration
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
 
 /**
  * Scan builder for DSv2 CoW snapshot reads.
- * Accepts column pruning and filter pushdown (partition pruning + data skipping).
  */
 class HoodieScanBuilder(spark: SparkSession,
                         metaClient: HoodieTableMetaClient,
@@ -40,12 +50,21 @@ class HoodieScanBuilder(spark: SparkSession,
                         options: Map[String, String]) extends ScanBuilder
   with SupportsPushDownFilters
   with SupportsPushDownRequiredColumns
+  with SupportsPushDownLimit
+  with SupportsPushDownAggregates
   with SparkAdapterSupport {
+
+  private val log = LoggerFactory.getLogger(getClass)
 
   private var requiredSchema: StructType = tableSchema
   private var _pushedFilters: Array[Filter] = Array.empty
   private var partitionFilterExprs: Seq[Expression] = Seq.empty
   private var dataFilterExprs: Seq[Expression] = Seq.empty
+  private var hasPostScanFilters: Boolean = false
+
+  private var pushedLimit: Option[Int] = None
+  private var pushedAggregation: Option[Aggregation] = None
+  private var aggregateResult: Option[Array[InternalRow]] = None
 
   private lazy val fileIndex = HoodieFileIndex(spark, metaClient, None, options,
     includeLogFiles = false, shouldEmbedFileSlices = false)
@@ -65,10 +84,8 @@ class HoodieScanBuilder(spark: SparkSession,
     dataFilterExprs = datFilters.toSeq
 
     _pushedFilters = pushed
+    hasPostScanFilters = postScan.nonEmpty
 
-    // Data filters are only used for file-level skipping (via metadata indices),
-    // not for row-level filtering. Return them as postScan so Spark applies
-    // row-level filtering. Partition filters are fully handled by partition pruning.
     val partFieldNames = fileIndex.partitionSchema.fieldNames.toSet
     val dataFilterArr = pushed.filterNot(f => f.references.forall(partFieldNames.contains))
     postScan ++ dataFilterArr
@@ -80,7 +97,56 @@ class HoodieScanBuilder(spark: SparkSession,
     this.requiredSchema = requiredSchema
   }
 
+  override def pushLimit(limit: Int): Boolean = {
+    pushedLimit = Some(limit)
+    true
+  }
+
+  override def isPartiallyPushed(): Boolean = true
+
+  override def pushAggregation(aggregation: Aggregation): Boolean = {
+    if (aggregation.groupByExpressions().nonEmpty) {
+      false
+    } else if (!MetadataPartitionType.COLUMN_STATS.isMetadataPartitionAvailable(metaClient)) {
+      false
+    } else {
+      val funcs = aggregation.aggregateExpressions()
+      val allSupported = funcs.forall {
+        case _: CountStar => true
+        case c: Count => !c.isDistinct
+        case _: Min => true
+        case _: Max => true
+        case _ => false
+      }
+      if (!allSupported) {
+        false
+      } else {
+        tryComputeAggregates(aggregation) match {
+          case Some(rows) =>
+            pushedAggregation = Some(aggregation)
+            aggregateResult = Some(rows)
+            true
+          case None => false
+        }
+      }
+    }
+  }
+
+  override def supportCompletePushDown(aggregation: Aggregation): Boolean = {
+    pushedAggregation.contains(aggregation) && dataFilterExprs.isEmpty && !hasPostScanFilters
+  }
+
   override def build(): Scan = {
+    aggregateResult match {
+      case Some(rows) =>
+        val outputSchema = buildAggregateOutputSchema(pushedAggregation.get)
+        new HoodieLocalScan(outputSchema, rows)
+      case None =>
+        buildSnapshotScan()
+    }
+  }
+
+  private def buildSnapshotScan(): Scan = {
     val partFieldNames = fileIndex.partitionSchema.fieldNames.toSet
     val requiredDataSchema = StructType(requiredSchema.filterNot(f => partFieldNames.contains(f.name)))
     val requiredPartitionSchema = StructType(requiredSchema.filter(f => partFieldNames.contains(f.name)))
@@ -95,8 +161,9 @@ class HoodieScanBuilder(spark: SparkSession,
     val fileSlicesPerPartition = fileIndex.filterFileSlices(dataFilterExprs, partitionFilterExprs)
 
     val partitions = fileSlicesPerPartition.flatMap { case (partitionOpt, fileSlices) =>
-      fileSlices.filter(fs => fs.getBaseFile.isPresent).map { fs =>
-        val baseFile = fs.getBaseFile.get()
+      fileSlices.filter(_.getBaseFile.isPresent).map { fs =>
+        val baseFilePath = fs.getBaseFile.get().getPath
+        val baseFileLength = fs.getBaseFile.get().getFileSize
         val allPartValues = partitionOpt.map(_.getValues).getOrElse(Array.empty[AnyRef])
 
         val partValues = if (requiredPartitionSchema.isEmpty) {
@@ -108,7 +175,7 @@ class HoodieScanBuilder(spark: SparkSession,
           }
         }
 
-        HoodieInputPartition(0, baseFile.getPath, baseFile.getFileSize, partValues)
+        HoodieInputPartition(0, baseFilePath, baseFileLength, partValues)
       }
     }.zipWithIndex.map { case (p, i) => p.copy(index = i) }.toArray[InputPartition]
 
@@ -119,6 +186,247 @@ class HoodieScanBuilder(spark: SparkSession,
       broadcastConf,
       requiredDataSchema,
       requiredPartitionSchema,
-      _pushedFilters)
+      _pushedFilters,
+      pushedLimit)
+  }
+
+  private def tryComputeAggregates(aggregation: Aggregation): Option[Array[InternalRow]] = {
+    try {
+      val fileSlicesPerPartition = fileIndex.filterFileSlices(dataFilterExprs, partitionFilterExprs)
+
+      if (dataFilterExprs.nonEmpty || hasPostScanFilters) {
+        None
+      } else {
+        // Collect base files as (partitionPath, fileName) pairs
+        val baseFiles = fileSlicesPerPartition.flatMap { case (partOpt, slices) =>
+          slices.filter(_.getBaseFile.isPresent).map { fs =>
+            val partPath = partOpt.map(_.getPath).getOrElse("")
+            val fileName = fs.getBaseFile.get().getFileName
+            (partPath, fileName)
+          }
+        }
+
+        if (baseFiles.isEmpty) {
+          Some(Array(buildEmptyAggregateRow(aggregation)))
+        } else {
+          computeAggregatesFromStats(aggregation, baseFiles)
+        }
+      }
+    } catch {
+      case e: Exception =>
+        log.debug("Aggregate pushdown computation failed, falling back to scan", e)
+        None
+    }
+  }
+
+  private def computeAggregatesFromStats(
+      aggregation: Aggregation,
+      baseFiles: Seq[(String, String)]): Option[Array[InternalRow]] = {
+    val aggFuncs = aggregation.aggregateExpressions()
+
+    // Determine which columns need stats; None if unsupported function found
+    val referencedColumnsOpt = aggFuncs.foldLeft(Option(Seq.empty[String])) { (accOpt, func) =>
+      accOpt.flatMap { acc =>
+        func match {
+          case _: CountStar => Some(acc)
+          case c: Count => extractColumnName(c.column()).map(name => acc :+ name)
+          case m: Min => extractColumnName(m.column()).map(name => acc :+ name)
+          case m: Max => extractColumnName(m.column()).map(name => acc :+ name)
+          case _ => None
+        }
+      }
+    }
+
+    referencedColumnsOpt.flatMap { referencedColumns =>
+      val distinctColumns = referencedColumns.distinct
+
+      // For CountStar, use the first table column to get total row count
+      val countStarColumnOpt: Option[Option[String]] = if (aggFuncs.exists(_.isInstanceOf[CountStar])) {
+        if (tableSchema.nonEmpty) Some(Some(tableSchema.fields.head.name)) else None
+      } else {
+        Some(None)
+      }
+
+      countStarColumnOpt.flatMap { countStarColumn =>
+        val allColumns = (distinctColumns ++ countStarColumn.toSeq).distinct
+        if (allColumns.isEmpty) {
+          None
+        } else {
+          queryAndComputeAggregates(aggFuncs, allColumns, countStarColumn, baseFiles)
+        }
+      }
+    }
+  }
+
+  private def queryAndComputeAggregates(
+      aggFuncs: Array[org.apache.spark.sql.connector.expressions.aggregate.AggregateFunc],
+      allColumns: Seq[String],
+      countStarColumn: Option[String],
+      baseFiles: Seq[(String, String)]): Option[Array[InternalRow]] = {
+    val metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build()
+    val engineContext = new HoodieLocalEngineContext(metaClient.getStorageConf)
+    val tableMetadata = new HoodieBackedTableMetadata(
+      engineContext, metaClient.getStorage, metadataConfig, metaClient.getBasePath.toString)
+
+    try {
+      val filePairs = baseFiles.map { case (part, file) => Pair.of(part, file) }.asJava
+
+      // Query stats for all needed columns; None if any column has incomplete stats
+      val columnStatsOpt = allColumns.foldLeft(
+        Option(Map.empty[String, Seq[HoodieColumnRangeMetadata[Comparable[_]]]])
+      ) { (accOpt, col) =>
+        accOpt.flatMap { acc =>
+          val statsMap = tableMetadata.getColumnStats(filePairs, col)
+          if (statsMap.size() != baseFiles.size) {
+            None
+          } else {
+            val allFileStats = statsMap.values().asScala
+              .map(cs => HoodieColumnRangeMetadata.fromColumnStats(cs)).toSeq
+            Some(acc + (col -> allFileStats))
+          }
+        }
+      }
+
+      columnStatsOpt.flatMap { columnStats =>
+        // Compute each aggregate value as Option; None means unsupported
+        val valuesOpt: Array[Option[Any]] = aggFuncs.map {
+          case _: CountStar =>
+            val stats = columnStats(countStarColumn.get)
+            Some(stats.map(s => s.getValueCount + s.getNullCount).sum: Any)
+
+          case c: Count =>
+            extractColumnName(c.column()).map { colName =>
+              val stats = columnStats(colName)
+              stats.map(_.getValueCount).sum: Any
+            }
+
+          case m: Min =>
+            for {
+              colName <- extractColumnName(m.column())
+              colType <- tableSchema.fields.find(_.name == colName).map(_.dataType)
+              result <- computeMinMax(columnStats(colName), colType, isMin = true)
+            } yield result
+
+          case m: Max =>
+            for {
+              colName <- extractColumnName(m.column())
+              colType <- tableSchema.fields.find(_.name == colName).map(_.dataType)
+              result <- computeMinMax(columnStats(colName), colType, isMin = false)
+            } yield result
+
+          case _ => None
+        }
+
+        if (valuesOpt.forall(_.isDefined)) {
+          Some(Array(new GenericInternalRow(valuesOpt.map(_.get))))
+        } else {
+          None
+        }
+      }
+    } finally {
+      tableMetadata.close()
+    }
+  }
+
+  private def computeMinMax(
+      allFileStats: Seq[HoodieColumnRangeMetadata[Comparable[_]]],
+      colType: DataType,
+      isMin: Boolean): Option[Any] = {
+    val rawValues = allFileStats.map(s => if (isMin) s.getMinValue else s.getMaxValue).filter(_ != null)
+    if (rawValues.isEmpty) {
+      Some(null)
+    } else {
+      val sparkValues = rawValues.flatMap(v => convertToSparkValue(v, colType))
+      if (sparkValues.size != rawValues.size) {
+        None
+      } else {
+        colType match {
+          case ByteType =>
+            val vs = sparkValues.map(_.asInstanceOf[Byte])
+            Some(if (isMin) vs.min else vs.max)
+          case ShortType =>
+            val vs = sparkValues.map(_.asInstanceOf[Short])
+            Some(if (isMin) vs.min else vs.max)
+          case IntegerType =>
+            val vs = sparkValues.map(_.asInstanceOf[Int])
+            Some(if (isMin) vs.min else vs.max)
+          case LongType =>
+            val vs = sparkValues.map(_.asInstanceOf[Long])
+            Some(if (isMin) vs.min else vs.max)
+          case FloatType =>
+            val vs = sparkValues.map(_.asInstanceOf[Float])
+            Some(if (isMin) vs.min else vs.max)
+          case DoubleType =>
+            val vs = sparkValues.map(_.asInstanceOf[Double])
+            Some(if (isMin) vs.min else vs.max)
+          case StringType =>
+            val vs = sparkValues.map(_.asInstanceOf[UTF8String])
+            Some(vs.reduce((a, b) => if ((isMin && a.compareTo(b) <= 0) || (!isMin && a.compareTo(b) >= 0)) a else b))
+          case _ => None
+        }
+      }
+    }
+  }
+
+  private def buildEmptyAggregateRow(aggregation: Aggregation): InternalRow = {
+    val values = aggregation.aggregateExpressions().map {
+      case _: CountStar => 0L: Any
+      case _: Count => 0L: Any
+      case _ => null: Any
+    }
+    new GenericInternalRow(values)
+  }
+
+  private def buildAggregateOutputSchema(aggregation: Aggregation): StructType = {
+    val fields = aggregation.aggregateExpressions().zipWithIndex.map { case (func, i) =>
+      func match {
+        case _: CountStar =>
+          StructField(s"count(*)", LongType, nullable = false)
+        case c: Count =>
+          val colName = extractColumnName(c.column()).getOrElse(s"col$i")
+          StructField(s"count($colName)", LongType, nullable = false)
+        case m: Min =>
+          val colName = extractColumnName(m.column()).getOrElse(s"col$i")
+          val colType = tableSchema.fields.find(_.name == colName).map(_.dataType).getOrElse(LongType)
+          StructField(s"min($colName)", colType, nullable = true)
+        case m: Max =>
+          val colName = extractColumnName(m.column()).getOrElse(s"col$i")
+          val colType = tableSchema.fields.find(_.name == colName).map(_.dataType).getOrElse(LongType)
+          StructField(s"max($colName)", colType, nullable = true)
+        case _ =>
+          StructField(s"agg$i", LongType, nullable = true)
+      }
+    }
+    StructType(fields)
+  }
+
+  private def extractColumnName(
+      expr: org.apache.spark.sql.connector.expressions.Expression): Option[String] = {
+    expr match {
+      case ref: NamedReference =>
+        val names = ref.fieldNames()
+        if (names.length == 1) Some(names.head) else None
+      case _ => None
+    }
+  }
+
+  private def convertToSparkValue(value: Any, dataType: DataType): Option[Any] = {
+    if (value == null) {
+      Some(null)
+    } else try {
+      dataType match {
+        case BooleanType => Some(value.asInstanceOf[Boolean])
+        case ByteType => Some(value.asInstanceOf[Number].byteValue())
+        case ShortType => Some(value.asInstanceOf[Number].shortValue())
+        case IntegerType => Some(value.asInstanceOf[Number].intValue())
+        case LongType => Some(value.asInstanceOf[Number].longValue())
+        case FloatType => Some(value.asInstanceOf[Number].floatValue())
+        case DoubleType => Some(value.asInstanceOf[Number].doubleValue())
+        case StringType => Some(UTF8String.fromString(value.toString))
+        case _ => None
+      }
+    } catch {
+      case _: Exception => None
+    }
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
@@ -17,21 +17,32 @@
 
 package org.apache.spark.sql.hudi.v2
 
-import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
+import org.apache.hudi.HoodieFileIndex
+import org.apache.hudi.SparkAdapterSupport
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.read.{InputPartition, Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
+import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.SerializableConfiguration
 
 /**
- * Stub scan builder that accepts column pruning and returns all filters as post-scan.
- * Filter pushdown will be implemented in a subsequent PR.
+ * Scan builder for DSv2 CoW snapshot reads.
+ * Accepts column pruning; filter pushdown deferred to a later PR.
  */
-class HoodieScanBuilder(tableSchema: StructType) extends ScanBuilder
+class HoodieScanBuilder(spark: SparkSession,
+                        metaClient: HoodieTableMetaClient,
+                        tableSchema: StructType,
+                        options: Map[String, String]) extends ScanBuilder
   with SupportsPushDownFilters
-  with SupportsPushDownRequiredColumns {
+  with SupportsPushDownRequiredColumns
+  with SparkAdapterSupport {
 
   private var requiredSchema: StructType = tableSchema
+
   override def pushFilters(filters: Array[Filter]): Array[Filter] = {
-    // Stub: all filters are returned as post-scan (none pushed down)
+    // All filters are returned as post-scan (none pushed down)
     filters
   }
 
@@ -41,5 +52,47 @@ class HoodieScanBuilder(tableSchema: StructType) extends ScanBuilder
     this.requiredSchema = requiredSchema
   }
 
-  override def build(): Scan = new HoodieBatchScan(requiredSchema)
+  override def build(): Scan = {
+    val fileIndex = HoodieFileIndex(spark, metaClient, None, options,
+      includeLogFiles = false, shouldEmbedFileSlices = false)
+
+    val partFieldNames = fileIndex.partitionSchema.fieldNames.toSet
+    val requiredDataSchema = StructType(requiredSchema.filterNot(f => partFieldNames.contains(f.name)))
+    val requiredPartitionSchema = StructType(requiredSchema.filter(f => partFieldNames.contains(f.name)))
+
+    val hadoopConf = spark.sessionState.newHadoopConf()
+    val readerOptions = options + (FileFormat.OPTION_RETURNING_BATCH -> "false")
+    val reader = sparkAdapter.createParquetFileReader(false, spark.sessionState.conf, readerOptions, hadoopConf)
+    val broadcastReader = spark.sparkContext.broadcast(reader)
+    val broadcastConf = spark.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
+
+    val fullPartSchema = fileIndex.partitionSchema
+    val fileSlicesPerPartition = fileIndex.filterFileSlices(Seq.empty, Seq.empty)
+
+    val partitions = fileSlicesPerPartition.flatMap { case (partitionOpt, fileSlices) =>
+      fileSlices.filter(fs => fs.getBaseFile.isPresent).map { fs =>
+        val baseFile = fs.getBaseFile.get()
+        val allPartValues = partitionOpt.map(_.getValues).getOrElse(Array.empty[AnyRef])
+
+        val partValues = if (requiredPartitionSchema.isEmpty) {
+          Array.empty[AnyRef]
+        } else {
+          requiredPartitionSchema.fieldNames.map { name =>
+            val idx = fullPartSchema.fieldIndex(name)
+            allPartValues(idx)
+          }
+        }
+
+        HoodieInputPartition(0, baseFile.getPath, baseFile.getFileSize, partValues)
+      }
+    }.zipWithIndex.map { case (p, i) => p.copy(index = i) }.toArray[InputPartition]
+
+    new HoodieBatchScan(
+      requiredSchema,
+      partitions,
+      broadcastReader,
+      broadcastConf,
+      requiredDataSchema,
+      requiredPartitionSchema)
+  }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieSparkV2Table.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieSparkV2Table.scala
@@ -34,12 +34,12 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import java.util
 
-import scala.collection.JavaConverters.{mapAsJavaMapConverter, setAsJavaSetConverter}
+import scala.collection.JavaConverters.{mapAsJavaMapConverter, mapAsScalaMapConverter, setAsJavaSetConverter}
 
 /**
  * DSv2 table implementation for Hudi.
  *
- * Read path: returns a stub [[HoodieScanBuilder]] that produces correct schema but empty results.
+ * Read path: uses [[HoodieScanBuilder]] to build COW snapshot scans via [[HoodieFileIndex]].
  * Write path: falls back to DSv1 via [[V2TableWithV1Fallback]] and [[HoodieV1WriteBuilder]].
  *
  * Schema is resolved via [[HoodieCatalogTable]] (catalog path) or [[HoodieTableMetaClient]] (DataFrame path).
@@ -83,7 +83,10 @@ case class HoodieSparkV2Table(spark: SparkSession,
   }
 
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
-    new HoodieScanBuilder(tableSchema)
+    val tableProps = properties().asScala.toMap
+    val scanOpts = options.asCaseSensitiveMap().asScala.toMap
+    val mergedOpts = tableProps ++ scanOpts
+    new HoodieScanBuilder(spark, metaClient, tableSchema, mergedOpts)
   }
 
   private def requireCatalogTable: HoodieCatalogTable =

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieSparkV2Table.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieSparkV2Table.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.hadoop.fs.HadoopFSUtils
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, HoodieCatalogTable}
+import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability, V1Table, V2TableWithV1Fallback}
+import org.apache.spark.sql.connector.catalog.TableCapability._
+import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform, Transform}
+import org.apache.spark.sql.connector.read.ScanBuilder
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
+import org.apache.spark.sql.hudi.HoodieSqlCommonUtils
+import org.apache.spark.sql.hudi.catalog.HoodieV1WriteBuilder
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import java.util
+
+import scala.collection.JavaConverters.{mapAsJavaMapConverter, setAsJavaSetConverter}
+
+/**
+ * DSv2 table implementation for Hudi.
+ *
+ * Read path: returns a stub [[HoodieScanBuilder]] that produces correct schema but empty results.
+ * Write path: falls back to DSv1 via [[V2TableWithV1Fallback]] and [[HoodieV1WriteBuilder]].
+ *
+ * Schema is resolved via [[HoodieCatalogTable]] (catalog path) or [[HoodieTableMetaClient]] (DataFrame path).
+ */
+case class HoodieSparkV2Table(spark: SparkSession,
+                              path: String,
+                              catalogTable: Option[CatalogTable] = None,
+                              options: CaseInsensitiveStringMap = CaseInsensitiveStringMap.empty())
+  extends Table with SupportsRead with SupportsWrite with V2TableWithV1Fallback {
+
+  lazy val hoodieCatalogTable: Option[HoodieCatalogTable] = catalogTable.map { ct =>
+    HoodieCatalogTable(spark, ct)
+  }
+
+  private lazy val metaClient: HoodieTableMetaClient = HoodieTableMetaClient.builder()
+    .setBasePath(path)
+    .setConf(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf))
+    .build()
+
+  private lazy val tableSchema: StructType = hoodieCatalogTable match {
+    case Some(hct) => hct.tableSchemaWithoutMetaFields
+    case None =>
+      HoodieSqlCommonUtils.getTableSqlSchema(metaClient, includeMetadataFields = false)
+        .getOrElse(new StructType())
+  }
+
+  override def name(): String = hoodieCatalogTable match {
+    case Some(hct) => hct.table.identifier.unquotedString
+    case None => metaClient.getTableConfig.getTableName
+  }
+
+  override def schema(): StructType = tableSchema
+
+  override def capabilities(): util.Set[TableCapability] = Set(
+    BATCH_READ, V1_BATCH_WRITE, OVERWRITE_BY_FILTER, TRUNCATE, ACCEPT_ANY_SCHEMA
+  ).asJava
+
+  override def properties(): util.Map[String, String] = hoodieCatalogTable match {
+    case Some(hct) => hct.catalogProperties.asJava
+    case None => java.util.Collections.emptyMap()
+  }
+
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+    new HoodieScanBuilder(tableSchema)
+  }
+
+  private def requireCatalogTable: HoodieCatalogTable =
+    hoodieCatalogTable.getOrElse(
+      throw new IllegalStateException(
+        "Write operations require a catalog table. " +
+          "DataFrame API writes are not supported via hudi_v2; use the SQL/catalog path."))
+
+  override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
+    new HoodieV1WriteBuilder(info.options, requireCatalogTable, spark)
+  }
+
+  override def v1Table: CatalogTable = requireCatalogTable.table
+
+  def v1TableWrapper: V1Table = V1Table(v1Table)
+
+  override def partitioning(): Array[Transform] = hoodieCatalogTable match {
+    case Some(hct) =>
+      hct.partitionFields.map { col =>
+        new IdentityTransform(new FieldReference(Seq(col)))
+      }.toArray
+    case None => Array.empty
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieStatistics.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieStatistics.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.spark.sql.connector.read.Statistics
+
+import java.util.OptionalLong
+
+/**
+ * Statistics for Spark CBO, reported by [[HoodieBatchScan]].
+ */
+class HoodieStatistics(sizeBytes: Long, rowCount: Option[Long] = None) extends Statistics {
+
+  override def sizeInBytes(): OptionalLong = OptionalLong.of(sizeBytes)
+
+  override def numRows(): OptionalLong =
+    rowCount.map(OptionalLong.of).getOrElse(OptionalLong.empty())
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CoexistenceWithDSv1.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CoexistenceWithDSv1.scala
@@ -1,0 +1,478 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.feature.v2
+
+import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils}
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
+/**
+ * Functional tests proving DSv2 and DSv1 coexistence.
+ *
+ * DataFrame API tests use `format("hudi_v2")` to activate the DSv2 path.
+ * SQL/Catalog tests use `hoodie.datasource.read.use.v2=true` to route through
+ * [[org.apache.spark.sql.hudi.catalog.HoodieCatalog.loadTable]] -> [[HoodieSparkV2Table]].
+ */
+@Tag("functional")
+class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
+
+  override def conf: SparkConf = conf(getSparkSqlConf)
+
+  @BeforeEach
+  def checkSparkVersion(): Unit = {
+    assumeTrue(HoodieSparkUtils.gteqSpark3_5,
+      "DSv2 read tests require Spark 3.5 or later")
+  }
+
+  private def writeTestData(path: String): Unit = {
+    val _spark = spark
+    import _spark.implicits._
+    val df = Seq(
+      (1, "Alice", 100.0),
+      (2, "Bob", 200.0),
+      (3, "Charlie", 300.0)
+    ).toDF("id", "name", "amount")
+
+    df.write.format("hudi")
+      .option("hoodie.table.name", "test_table")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+  }
+
+  private def containsBatchScan(plan: String): Boolean = plan.contains("BatchScan")
+
+  private def containsFileScan(plan: String): Boolean = plan.contains("FileScan")
+
+  // ---- DataFrame API write tests ----
+
+  @Test
+  def testDSv2WriteViaDataFrameAPI(): Unit = {
+    val path = basePath() + "/v2_write_df_api"
+    val _spark = spark
+    import _spark.implicits._
+    val df = Seq(
+      (1, "Alice", 100.0),
+      (2, "Bob", 200.0),
+      (3, "Charlie", 300.0)
+    ).toDF("id", "name", "amount")
+
+    df.write.format("hudi_v2")
+      .option("hoodie.table.name", "test_v2_write")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Append)
+      .save(path)
+
+    // Read back via DSv1 to verify data was written correctly
+    val result = spark.read.format("hudi").load(path)
+    assertEquals(3, result.count())
+
+    val names = result.select("name").collect().map(_.getString(0)).sorted
+    assertEquals(Array("Alice", "Bob", "Charlie").toSeq, names.toSeq)
+  }
+
+  // ---- DataFrame API read tests ----
+
+  @Test
+  def testBaselineDSv1WriteAndRead(): Unit = {
+    val path = basePath() + "/baseline_v1"
+    writeTestData(path)
+
+    val df = spark.read.format("hudi").load(path)
+    assertEquals(3, df.count())
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsFileScan(plan),
+      s"DSv1 read should use FileScan, but plan was:\n$plan")
+  }
+
+  @Test
+  def testDSv1WriteAndDSv2Read(): Unit = {
+    val path = basePath() + "/v1_write_v2_read"
+    writeTestData(path)
+
+    val df = spark.read.format("hudi_v2").load(path)
+    // DSv2 stub returns empty results
+    assertEquals(0, df.count())
+
+    // Schema should still be correct (contains at least the user columns)
+    val fieldNames = df.schema.fieldNames
+    assertTrue(fieldNames.contains("id"), s"Schema should contain 'id', got: ${fieldNames.mkString(", ")}")
+    assertTrue(fieldNames.contains("name"), s"Schema should contain 'name', got: ${fieldNames.mkString(", ")}")
+    assertTrue(fieldNames.contains("amount"), s"Schema should contain 'amount', got: ${fieldNames.mkString(", ")}")
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
+  }
+
+  @Test
+  def testDSv1WriteAndDSv1ReadAfterDSv2Read(): Unit = {
+    val path = basePath() + "/v1_write_both_read"
+    writeTestData(path)
+
+    // DSv2 read returns empty (stub)
+    val v2Df = spark.read.format("hudi_v2").load(path)
+    assertEquals(0, v2Df.count())
+
+    // DSv1 read still works after DSv2 read
+    val df = spark.read.format("hudi").load(path)
+    assertEquals(3, df.count())
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsFileScan(plan),
+      s"DSv1 read should use FileScan, but plan was:\n$plan")
+  }
+
+  @Test
+  def testDSv2ReadSchemaAndPlan(): Unit = {
+    val path = basePath() + "/v2_read_schema"
+    writeTestData(path)
+
+    val df = spark.read.format("hudi_v2").load(path)
+    // DSv2 stub returns empty results
+    assertEquals(0, df.count())
+
+    // Verify schema is correct
+    val fieldNames = df.schema.fieldNames
+    assertTrue(fieldNames.contains("id"), s"Schema should contain 'id', got: ${fieldNames.mkString(", ")}")
+    assertTrue(fieldNames.contains("name"), s"Schema should contain 'name', got: ${fieldNames.mkString(", ")}")
+    assertTrue(fieldNames.contains("amount"), s"Schema should contain 'amount', got: ${fieldNames.mkString(", ")}")
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
+  }
+
+  // ---- SQL/Catalog tests ----
+
+  @Test
+  def testSqlConfigFalseUsesDSv1(): Unit = {
+    val tableName = "sql_v1_test"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  ts LONG
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 2), (3, 'Charlie', 300.0, 3)")
+
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "false")
+    try {
+      val df = spark.sql(s"SELECT * FROM $tableName")
+      assertEquals(3, df.count())
+
+      val plan = df.queryExecution.executedPlan.toString()
+      assertTrue(containsFileScan(plan),
+        s"With use.v2=false, should use FileScan, but plan was:\n$plan")
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testSqlConfigTrueUsesDSv2Stub(): Unit = {
+    val tableName = "sql_v2_test"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  ts LONG
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 2), (3, 'Charlie', 300.0, 3)")
+
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    try {
+      val df = spark.sql(s"SELECT * FROM $tableName")
+      // DSv2 stub returns empty
+      assertEquals(0, df.count())
+
+      val fieldNames = df.schema.fieldNames
+      assertTrue(fieldNames.contains("id"), s"Schema should contain 'id', got: ${fieldNames.mkString(", ")}")
+      assertTrue(fieldNames.contains("name"), s"Schema should contain 'name', got: ${fieldNames.mkString(", ")}")
+
+      val plan = df.queryExecution.executedPlan.toString()
+      assertTrue(containsBatchScan(plan),
+        s"With use.v2=true, should use BatchScan, but plan was:\n$plan")
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testSqlSwitchBetweenV1AndV2Reads(): Unit = {
+    val tableName = "sql_switch_read_test"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  ts LONG
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    // Write with v1 (default)
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 2), (3, 'Charlie', 300.0, 3)")
+
+    // Read with v2 — stub returns empty
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    try {
+      val v2Df = spark.sql(s"SELECT * FROM $tableName")
+      assertEquals(0, v2Df.count())
+
+      val v2Plan = v2Df.queryExecution.executedPlan.toString()
+      assertTrue(containsBatchScan(v2Plan),
+        s"V2 read should use BatchScan, but plan was:\n$v2Plan")
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+    }
+
+    // Switch back to v1 — should see real data
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "false")
+    try {
+      val v1Df = spark.sql(s"SELECT * FROM $tableName")
+      assertEquals(3, v1Df.count())
+
+      val v1Plan = v1Df.queryExecution.executedPlan.toString()
+      assertTrue(containsFileScan(v1Plan),
+        s"V1 read should use FileScan, but plan was:\n$v1Plan")
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testSqlInsertWithV2ReadEnabled(): Unit = {
+    val tableName = "sql_v2_insert_test"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  ts LONG
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    // Enable V2 read BEFORE inserting — write should still work via V1 fallback
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    try {
+      spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 2)")
+
+      // Verify data was written by reading back via V1
+      spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "false")
+      val df = spark.sql(s"SELECT * FROM $tableName")
+      assertEquals(2, df.count())
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testDdlOperationsWithV2ReadEnabled(): Unit = {
+    val tableName = "sql_v2_ddl_test"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  ts LONG
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1)")
+
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    try {
+      // ALTER TABLE should work with V2 read enabled
+      spark.sql(s"ALTER TABLE $tableName ADD COLUMNS (extra STRING)")
+
+      // Verify the column was added by checking schema
+      val df = spark.sql(s"DESCRIBE $tableName")
+      val colNames = df.select("col_name").collect().map(_.getString(0))
+      assertTrue(colNames.contains("extra"),
+        s"ALTER TABLE ADD COLUMNS should work with v2 read enabled, columns: ${colNames.mkString(", ")}")
+
+      // DROP TABLE should work with V2 read enabled
+      spark.sql(s"DROP TABLE $tableName")
+
+      // Verify table was dropped
+      val tables = spark.sql("SHOW TABLES").collect().map(_.getString(1))
+      assertTrue(!tables.contains(tableName),
+        s"DROP TABLE should work with v2 read enabled, tables: ${tables.mkString(", ")}")
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testSchemaEvolutionPathUnaffectedByV2Config(): Unit = {
+    val tableName = "sql_schema_evol_test"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  ts LONG
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1)")
+
+    // With schema evolution enabled and v2 read disabled, the loadTable()
+    // should return HoodieInternalV2Table (schema evolution path), not V1Table.
+    // Verify via EXPLAIN that the plan uses BatchScan (V2 path), not FileScan (V1 path).
+    spark.sessionState.conf.setConfString("hoodie.schema.on.read.enable", "true")
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "false")
+    try {
+      val explainRows = spark.sql(s"EXPLAIN SELECT * FROM $tableName").collect()
+      val plan = explainRows.map(_.getString(0)).mkString("\n")
+      assertTrue(containsBatchScan(plan),
+        s"Schema evolution path should use BatchScan (V2), but got:\n$plan")
+
+      val df = spark.sql(s"SELECT * FROM $tableName")
+      assertEquals(1, df.count())
+    } finally {
+      spark.sessionState.conf.unsetConf("hoodie.schema.on.read.enable")
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+    }
+
+    // With both schema evolution and v2 read enabled, the loadTable() should
+    // return HoodieSparkV2Table (DSv2 path takes precedence over schema evolution).
+    spark.sessionState.conf.setConfString("hoodie.schema.on.read.enable", "true")
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    try {
+      val explainRows = spark.sql(s"EXPLAIN SELECT * FROM $tableName").collect()
+      val plan = explainRows.map(_.getString(0)).mkString("\n")
+      assertTrue(containsBatchScan(plan),
+        s"V2 read with schema evolution should use BatchScan (V2), but got:\n$plan")
+
+      val df = spark.sql(s"SELECT * FROM $tableName")
+      assertEquals(1, df.count())
+    } finally {
+      spark.sessionState.conf.unsetConf("hoodie.schema.on.read.enable")
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testExplainShowsDSv2(): Unit = {
+    val tableName = "sql_explain_test"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  ts LONG
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1)")
+
+    // Verify V1 EXPLAIN shows FileScan
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "false")
+    try {
+      val v1ExplainRows = spark.sql(s"EXPLAIN SELECT * FROM $tableName").collect()
+      val v1Plan = v1ExplainRows.map(_.getString(0)).mkString("\n")
+      assertTrue(containsFileScan(v1Plan),
+        s"V1 EXPLAIN should contain FileScan, but got:\n$v1Plan")
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+    }
+
+    // Verify V2 EXPLAIN shows BatchScan
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    try {
+      val v2ExplainRows = spark.sql(s"EXPLAIN SELECT * FROM $tableName").collect()
+      val v2Plan = v2ExplainRows.map(_.getString(0)).mkString("\n")
+      assertTrue(containsBatchScan(v2Plan),
+        s"V2 EXPLAIN should contain BatchScan, but got:\n$v2Plan")
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CoexistenceWithDSv1.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CoexistenceWithDSv1.scala
@@ -17,15 +17,14 @@
 
 package org.apache.spark.sql.hudi.feature.v2
 
-import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils}
+import org.apache.hudi.DataSourceReadOptions
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SaveMode
-import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import org.junit.jupiter.api.{Tag, Test}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.junit.jupiter.api.Assumptions.assumeTrue
 
 /**
  * Functional tests proving DSv2 and DSv1 coexistence.
@@ -38,12 +37,6 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
 
   override def conf: SparkConf = conf(getSparkSqlConf)
-
-  @BeforeEach
-  def checkSparkVersion(): Unit = {
-    assumeTrue(HoodieSparkUtils.gteqSpark3_5,
-      "DSv2 read tests require Spark 3.5 or later")
-  }
 
   private def writeTestData(path: String): Unit = {
     val _spark = spark

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CoexistenceWithDSv1.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CoexistenceWithDSv1.scala
@@ -115,14 +115,10 @@ class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
     writeTestData(path)
 
     val df = spark.read.format("hudi_v2").load(path)
-    // DSv2 stub returns empty results
-    assertEquals(0, df.count())
+    assertEquals(3, df.count())
 
-    // Schema should still be correct (contains at least the user columns)
-    val fieldNames = df.schema.fieldNames
-    assertTrue(fieldNames.contains("id"), s"Schema should contain 'id', got: ${fieldNames.mkString(", ")}")
-    assertTrue(fieldNames.contains("name"), s"Schema should contain 'name', got: ${fieldNames.mkString(", ")}")
-    assertTrue(fieldNames.contains("amount"), s"Schema should contain 'amount', got: ${fieldNames.mkString(", ")}")
+    val names = df.select("name").collect().map(_.getString(0)).sorted
+    assertEquals(Seq("Alice", "Bob", "Charlie"), names.toSeq)
 
     val plan = df.queryExecution.executedPlan.toString()
     assertTrue(containsBatchScan(plan),
@@ -134,9 +130,9 @@ class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
     val path = basePath() + "/v1_write_both_read"
     writeTestData(path)
 
-    // DSv2 read returns empty (stub)
+    // DSv2 read returns real data
     val v2Df = spark.read.format("hudi_v2").load(path)
-    assertEquals(0, v2Df.count())
+    assertEquals(3, v2Df.count())
 
     // DSv1 read still works after DSv2 read
     val df = spark.read.format("hudi").load(path)
@@ -153,14 +149,17 @@ class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
     writeTestData(path)
 
     val df = spark.read.format("hudi_v2").load(path)
-    // DSv2 stub returns empty results
-    assertEquals(0, df.count())
+    assertEquals(3, df.count())
 
     // Verify schema is correct
     val fieldNames = df.schema.fieldNames
     assertTrue(fieldNames.contains("id"), s"Schema should contain 'id', got: ${fieldNames.mkString(", ")}")
     assertTrue(fieldNames.contains("name"), s"Schema should contain 'name', got: ${fieldNames.mkString(", ")}")
     assertTrue(fieldNames.contains("amount"), s"Schema should contain 'amount', got: ${fieldNames.mkString(", ")}")
+
+    // Verify data values
+    val names = df.select("name").collect().map(_.getString(0)).sorted
+    assertEquals(Seq("Alice", "Bob", "Charlie"), names.toSeq)
 
     val plan = df.queryExecution.executedPlan.toString()
     assertTrue(containsBatchScan(plan),
@@ -205,7 +204,7 @@ class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
   }
 
   @Test
-  def testSqlConfigTrueUsesDSv2Stub(): Unit = {
+  def testSqlConfigTrueUsesDSv2(): Unit = {
     val tableName = "sql_v2_test"
     val tablePath = basePath() + "/" + tableName
     spark.sql(
@@ -228,12 +227,10 @@ class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
     spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
     try {
       val df = spark.sql(s"SELECT * FROM $tableName")
-      // DSv2 stub returns empty
-      assertEquals(0, df.count())
+      assertEquals(3, df.count())
 
-      val fieldNames = df.schema.fieldNames
-      assertTrue(fieldNames.contains("id"), s"Schema should contain 'id', got: ${fieldNames.mkString(", ")}")
-      assertTrue(fieldNames.contains("name"), s"Schema should contain 'name', got: ${fieldNames.mkString(", ")}")
+      val names = df.select("name").collect().map(_.getString(0)).sorted
+      assertEquals(Seq("Alice", "Bob", "Charlie"), names.toSeq)
 
       val plan = df.queryExecution.executedPlan.toString()
       assertTrue(containsBatchScan(plan),
@@ -266,11 +263,11 @@ class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
     // Write with v1 (default)
     spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 2), (3, 'Charlie', 300.0, 3)")
 
-    // Read with v2 — stub returns empty
+    // Read with v2 — returns real data
     spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
     try {
       val v2Df = spark.sql(s"SELECT * FROM $tableName")
-      assertEquals(0, v2Df.count())
+      assertEquals(3, v2Df.count())
 
       val v2Plan = v2Df.queryExecution.executedPlan.toString()
       assertTrue(containsBatchScan(v2Plan),
@@ -279,7 +276,7 @@ class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
       spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
     }
 
-    // Switch back to v1 — should see real data
+    // Switch back to v1 — should also see real data
     spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "false")
     try {
       val v1Df = spark.sql(s"SELECT * FROM $tableName")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CowSnapshotRead.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CowSnapshotRead.scala
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.feature.v2
+
+import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils}
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
+/**
+ * Functional tests for COW snapshot reading via the DSv2 path.
+ */
+@Tag("functional")
+class TestDSv2CowSnapshotRead extends SparkClientFunctionalTestHarness {
+
+  override def conf: SparkConf = conf(getSparkSqlConf)
+
+  @BeforeEach
+  def checkSparkVersion(): Unit = {
+    assumeTrue(HoodieSparkUtils.gteqSpark3_5,
+      "DSv2 read tests require Spark 3.5 or later")
+  }
+
+  @Test
+  def testCowReadViaDataFrameApi(): Unit = {
+    val path = basePath() + "/cow_df_read"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq((1, "Alice", 100.0), (2, "Bob", 200.0), (3, "Charlie", 300.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_df_read")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path)
+    assertEquals(3, df.count())
+
+    val names = df.select("name").collect().map(_.getString(0)).sorted
+    assertEquals(Seq("Alice", "Bob", "Charlie"), names.toSeq)
+
+    // Verify values match DSv1 read
+    val v1Names = spark.read.format("hudi").load(path)
+      .select("name").collect().map(_.getString(0)).sorted
+    assertEquals(v1Names.toSeq, names.toSeq)
+  }
+
+  @Test
+  def testCowReadViaSqlCatalog(): Unit = {
+    val tableName = "cow_sql_read"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  ts LONG
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 2), (3, 'Charlie', 300.0, 3)")
+
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    try {
+      val v2Df = spark.sql(s"SELECT * FROM $tableName")
+      assertEquals(3, v2Df.count())
+
+      spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "false")
+      val v1Df = spark.sql(s"SELECT * FROM $tableName")
+      assertEquals(3, v1Df.count())
+
+      // Compare values (exclude meta-fields from V1)
+      val v2Names = v2Df.select("name").collect().map(_.getString(0)).sorted
+      val v1Names = v1Df.select("name").collect().map(_.getString(0)).sorted
+      assertEquals(v1Names.toSeq, v2Names.toSeq)
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testColumnPruning(): Unit = {
+    val path = basePath() + "/cow_col_pruning"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq((1, "Alice", 100.0), (2, "Bob", 200.0), (3, "Charlie", 300.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_col_pruning")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path).select("id", "name")
+    assertEquals(2, df.schema.fields.length)
+    assertEquals(3, df.count())
+
+    val rows = df.collect().map(r => (r.getInt(0), r.getString(1))).sortBy(_._1)
+    assertEquals(Seq((1, "Alice"), (2, "Bob"), (3, "Charlie")), rows.toSeq)
+  }
+
+  @Test
+  def testNonPartitionedTable(): Unit = {
+    val path = basePath() + "/cow_non_partitioned"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq((1, "Alice", 100.0), (2, "Bob", 200.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_non_partitioned")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path)
+    assertEquals(2, df.count())
+
+    val ids = df.select("id").collect().map(_.getInt(0)).sorted
+    assertEquals(Seq(1, 2), ids.toSeq)
+  }
+
+  @Test
+  def testPartitionedTable(): Unit = {
+    val path = basePath() + "/cow_partitioned"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq((1, "Alice", "US"), (2, "Bob", "UK"), (3, "Charlie", "US"))
+      .toDF("id", "name", "country")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_partitioned")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "id")
+      .option("hoodie.datasource.write.partitionpath.field", "country")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path)
+    assertEquals(3, df.count())
+
+    val countries = df.select("country").collect().map(_.getString(0)).sorted
+    assertEquals(Seq("UK", "US", "US"), countries.toSeq)
+
+    val names = df.select("name").collect().map(_.getString(0)).sorted
+    assertEquals(Seq("Alice", "Bob", "Charlie"), names.toSeq)
+  }
+
+  @Test
+  def testMultipleCommits(): Unit = {
+    val path = basePath() + "/cow_multi_commit"
+    val _spark = spark
+    import _spark.implicits._
+
+    // Batch 1: insert
+    Seq((1, "Alice", 100.0), (2, "Bob", 200.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_multi_commit")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    // Batch 2: upsert (update Alice's amount, insert Charlie)
+    Seq((1, "Alice", 150.0), (3, "Charlie", 300.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_multi_commit")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Append)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path)
+    assertEquals(3, df.count())
+
+    val rows = df.select("id", "name", "amount").collect()
+      .map(r => (r.getInt(0), r.getString(1), r.getDouble(2))).sortBy(_._1)
+    assertEquals(Seq((1, "Alice", 150.0), (2, "Bob", 200.0), (3, "Charlie", 300.0)), rows.toSeq)
+  }
+
+  @Test
+  def testDsv1VsDsv2ResultComparison(): Unit = {
+    val path = basePath() + "/cow_v1_v2_compare"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq((1, "Alice", 100.0), (2, "Bob", 200.0), (3, "Charlie", 300.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_v1_v2_compare")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val v1Df = spark.read.format("hudi").load(path).select("id", "name", "amount")
+    val v2Df = spark.read.format("hudi_v2").load(path).select("id", "name", "amount")
+
+    val v1Rows = v1Df.collect().map(r => (r.getInt(0), r.getString(1), r.getDouble(2))).sortBy(_._1)
+    val v2Rows = v2Df.collect().map(r => (r.getInt(0), r.getString(1), r.getDouble(2))).sortBy(_._1)
+    assertEquals(v1Rows.toSeq, v2Rows.toSeq)
+  }
+
+  @Test
+  def testSelectPartitionColumnOnly(): Unit = {
+    val path = basePath() + "/cow_select_part_only"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq((1, "Alice", "US"), (2, "Bob", "UK"), (3, "Charlie", "US"))
+      .toDF("id", "name", "country")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_select_part_only")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "id")
+      .option("hoodie.datasource.write.partitionpath.field", "country")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path).select("country")
+    assertEquals(3, df.count())
+
+    val countries = df.collect().map(_.getString(0)).sorted
+    assertEquals(Seq("UK", "US", "US"), countries.toSeq)
+  }
+
+  @Test
+  def testMultiplePartitions(): Unit = {
+    val path = basePath() + "/cow_multi_partitions"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq(
+      (1, "Alice", "US"),
+      (2, "Bob", "UK"),
+      (3, "Charlie", "DE"),
+      (4, "Diana", "US"),
+      (5, "Eve", "UK")
+    ).toDF("id", "name", "country")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_multi_partitions")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "id")
+      .option("hoodie.datasource.write.partitionpath.field", "country")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path)
+    assertEquals(5, df.count())
+
+    val distinctCountries = df.select("country").distinct().collect().map(_.getString(0)).sorted
+    assertEquals(Seq("DE", "UK", "US"), distinctCountries.toSeq)
+
+    // Verify counts per partition
+    val countsByCountry = df.groupBy("country").count().collect()
+      .map(r => (r.getString(0), r.getLong(1))).toMap
+    assertEquals(2L, countsByCountry("US"))
+    assertEquals(2L, countsByCountry("UK"))
+    assertEquals(1L, countsByCountry("DE"))
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CowSnapshotRead.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CowSnapshotRead.scala
@@ -17,15 +17,14 @@
 
 package org.apache.spark.sql.hudi.feature.v2
 
-import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils}
+import org.apache.hudi.DataSourceReadOptions
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SaveMode
-import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import org.junit.jupiter.api.{Tag, Test}
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assumptions.assumeTrue
 
 /**
  * Functional tests for COW snapshot reading via the DSv2 path.
@@ -34,12 +33,6 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 class TestDSv2CowSnapshotRead extends SparkClientFunctionalTestHarness {
 
   override def conf: SparkConf = conf(getSparkSqlConf)
-
-  @BeforeEach
-  def checkSparkVersion(): Unit = {
-    assumeTrue(HoodieSparkUtils.gteqSpark3_5,
-      "DSv2 read tests require Spark 3.5 or later")
-  }
 
   @Test
   def testCowReadViaDataFrameApi(): Unit = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2FilterPushdown.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2FilterPushdown.scala
@@ -17,15 +17,14 @@
 
 package org.apache.spark.sql.hudi.feature.v2
 
-import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils}
+import org.apache.hudi.DataSourceReadOptions
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SaveMode
-import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import org.junit.jupiter.api.{Tag, Test}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.junit.jupiter.api.Assumptions.assumeTrue
 
 /**
  * Functional tests for filter pushdown (partition pruning + data filters) via the DSv2 path.
@@ -34,12 +33,6 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 class TestDSv2FilterPushdown extends SparkClientFunctionalTestHarness {
 
   override def conf: SparkConf = conf(getSparkSqlConf)
-
-  @BeforeEach
-  def checkSparkVersion(): Unit = {
-    assumeTrue(HoodieSparkUtils.gteqSpark3_5,
-      "DSv2 read tests require Spark 3.5 or later")
-  }
 
   private def writePartitionedData(path: String, tableName: String): Unit = {
     val _spark = spark

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2FilterPushdown.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2FilterPushdown.scala
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.feature.v2
+
+import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils}
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
+/**
+ * Functional tests for filter pushdown (partition pruning + data filters) via the DSv2 path.
+ */
+@Tag("functional")
+class TestDSv2FilterPushdown extends SparkClientFunctionalTestHarness {
+
+  override def conf: SparkConf = conf(getSparkSqlConf)
+
+  @BeforeEach
+  def checkSparkVersion(): Unit = {
+    assumeTrue(HoodieSparkUtils.gteqSpark3_5,
+      "DSv2 read tests require Spark 3.5 or later")
+  }
+
+  private def writePartitionedData(path: String, tableName: String): Unit = {
+    val _spark = spark
+    import _spark.implicits._
+    Seq(
+      (1, "Alice", 100.0, "US"),
+      (2, "Bob", 200.0, "UK"),
+      (3, "Charlie", 300.0, "US"),
+      (4, "Diana", 150.0, "FR"),
+      (5, "Eve", 250.0, "UK")
+    ).toDF("id", "name", "amount", "country")
+      .write.format("hudi")
+      .option("hoodie.table.name", tableName)
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .option("hoodie.datasource.write.partitionpath.field", "country")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+  }
+
+  @Test
+  def testPartitionPruning(): Unit = {
+    val path = basePath() + "/filter_part_prune"
+    writePartitionedData(path, "filter_part_prune")
+
+    val df = spark.read.format("hudi_v2").load(path).filter("country = 'US'")
+    val rows = df.select("id", "name", "country").collect()
+      .map(r => (r.getInt(0), r.getString(1), r.getString(2))).sortBy(_._1)
+
+    assertEquals(2, rows.length)
+    assertEquals(Seq((1, "Alice", "US"), (3, "Charlie", "US")), rows.toSeq)
+  }
+
+  @Test
+  def testPartitionPruningViaSql(): Unit = {
+    val tableName = "filter_sql_prune"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  country STRING
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'amount'
+         |)
+         |PARTITIONED BY (country)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    spark.sql(
+      s"""INSERT INTO $tableName VALUES
+         |(1, 'Alice', 100.0, 'US'),
+         |(2, 'Bob', 200.0, 'UK'),
+         |(3, 'Charlie', 300.0, 'US')
+         """.stripMargin)
+
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    try {
+      val df = spark.sql(s"SELECT * FROM $tableName WHERE country = 'US'")
+      assertEquals(2, df.count())
+
+      val names = df.select("name").collect().map(_.getString(0)).sorted
+      assertEquals(Seq("Alice", "Charlie"), names.toSeq)
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testDataFilterPushdown(): Unit = {
+    val path = basePath() + "/filter_data_push"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq(
+      (1, "Alice", 100.0),
+      (2, "Bob", 200.0),
+      (3, "Charlie", 300.0),
+      (4, "Diana", 400.0),
+      (5, "Eve", 500.0)
+    ).toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "filter_data_push")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path).filter("id > 3")
+    val rows = df.select("id", "name").collect()
+      .map(r => (r.getInt(0), r.getString(1))).sortBy(_._1)
+
+    assertEquals(2, rows.length)
+    assertEquals(Seq((4, "Diana"), (5, "Eve")), rows.toSeq)
+  }
+
+  @Test
+  def testMixedPartitionAndDataFilters(): Unit = {
+    val path = basePath() + "/filter_mixed"
+    writePartitionedData(path, "filter_mixed")
+
+    val df = spark.read.format("hudi_v2").load(path)
+      .filter("country = 'US' AND name = 'Alice'")
+    val rows = df.select("id", "name", "country").collect()
+      .map(r => (r.getInt(0), r.getString(1), r.getString(2)))
+
+    assertEquals(1, rows.length)
+    assertEquals((1, "Alice", "US"), rows.head)
+  }
+
+  @Test
+  def testExplainShowsPushedFilters(): Unit = {
+    val path = basePath() + "/filter_explain"
+    writePartitionedData(path, "filter_explain")
+
+    val df = spark.read.format("hudi_v2").load(path).filter("country = 'US'")
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(plan.contains("BatchScan"), s"Expected BatchScan in plan:\n$plan")
+    assertTrue(plan.contains("PushedFilters"), s"Expected PushedFilters in plan:\n$plan")
+    assertTrue(plan.contains("country"), s"Expected 'country' in pushed filters:\n$plan")
+  }
+
+  @Test
+  def testDsv1VsDsv2FilterResults(): Unit = {
+    val path = basePath() + "/filter_v1_v2"
+    writePartitionedData(path, "filter_v1_v2")
+
+    val filter = "country = 'UK'"
+    val v1Rows = spark.read.format("hudi").load(path).filter(filter)
+      .select("id", "name", "amount", "country").collect()
+      .map(r => (r.getInt(0), r.getString(1), r.getDouble(2), r.getString(3))).sortBy(_._1)
+
+    val v2Rows = spark.read.format("hudi_v2").load(path).filter(filter)
+      .select("id", "name", "amount", "country").collect()
+      .map(r => (r.getInt(0), r.getString(1), r.getDouble(2), r.getString(3))).sortBy(_._1)
+
+    assertEquals(v1Rows.toSeq, v2Rows.toSeq)
+    assertEquals(2, v2Rows.length)
+  }
+
+  @Test
+  def testNoFilterScansAllPartitions(): Unit = {
+    val path = basePath() + "/filter_no_filter"
+    writePartitionedData(path, "filter_no_filter")
+
+    val df = spark.read.format("hudi_v2").load(path)
+    assertEquals(5, df.count())
+
+    val countries = df.select("country").distinct().collect().map(_.getString(0)).sorted
+    assertEquals(Seq("FR", "UK", "US"), countries.toSeq)
+  }
+
+  @Test
+  def testInFilterOnPartitionColumn(): Unit = {
+    val path = basePath() + "/filter_in"
+    writePartitionedData(path, "filter_in")
+
+    val df = spark.read.format("hudi_v2").load(path).filter("country IN ('US', 'UK')")
+    assertEquals(4, df.count())
+
+    val countries = df.select("country").distinct().collect().map(_.getString(0)).sorted
+    assertEquals(Seq("UK", "US"), countries.toSeq)
+  }
+
+  @Test
+  def testIsNullFilter(): Unit = {
+    val path = basePath() + "/filter_null"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq(
+      (1, "Alice", "US"),
+      (2, "Bob", null: String),
+      (3, "Charlie", "UK"),
+      (4, "Diana", null: String)
+    ).toDF("id", "name", "country")
+      .write.format("hudi")
+      .option("hoodie.table.name", "filter_null")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "id")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path).filter("country IS NULL")
+    assertEquals(2, df.count())
+
+    val ids = df.select("id").collect().map(_.getInt(0)).sorted
+    assertEquals(Seq(2, 4), ids.toSeq)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2Pushdowns.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2Pushdowns.scala
@@ -17,15 +17,13 @@
 
 package org.apache.spark.sql.hudi.feature.v2
 
-import org.apache.hudi.HoodieSparkUtils
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SaveMode
-import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import org.junit.jupiter.api.{Tag, Test}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.junit.jupiter.api.Assumptions.assumeTrue
 
 /**
  * Functional tests for limit pushdown, statistics reporting, and aggregate pushdown via DSv2.
@@ -34,12 +32,6 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
 
   override def conf: SparkConf = conf(getSparkSqlConf)
-
-  @BeforeEach
-  def checkSparkVersion(): Unit = {
-    assumeTrue(HoodieSparkUtils.gteqSpark3_5,
-      "DSv2 read tests require Spark 3.5 or later")
-  }
 
   private def writeTestData(path: String, tableName: String, numRecords: Int = 10): Unit = {
     val _spark = spark

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2Pushdowns.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2Pushdowns.scala
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.feature.v2
+
+import org.apache.hudi.HoodieSparkUtils
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
+/**
+ * Functional tests for limit pushdown, statistics reporting, and aggregate pushdown via DSv2.
+ */
+@Tag("functional")
+class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
+
+  override def conf: SparkConf = conf(getSparkSqlConf)
+
+  @BeforeEach
+  def checkSparkVersion(): Unit = {
+    assumeTrue(HoodieSparkUtils.gteqSpark3_5,
+      "DSv2 read tests require Spark 3.5 or later")
+  }
+
+  private def writeTestData(path: String, tableName: String, numRecords: Int = 10): Unit = {
+    val _spark = spark
+    import _spark.implicits._
+    (1 to numRecords).map(i => (i, s"name_$i", i * 100.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", tableName)
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+  }
+
+  private def writePartitionedTestData(path: String, tableName: String): Unit = {
+    val _spark = spark
+    import _spark.implicits._
+    Seq(
+      (1, "Alice", 100.0, "US"),
+      (2, "Bob", 200.0, "UK"),
+      (3, "Charlie", 300.0, "US"),
+      (4, "Diana", 150.0, "FR"),
+      (5, "Eve", 250.0, "UK"),
+      (6, "Frank", 350.0, "US"),
+      (7, "Grace", 450.0, "FR")
+    ).toDF("id", "name", "amount", "country")
+      .write.format("hudi")
+      .option("hoodie.table.name", tableName)
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .option("hoodie.datasource.write.partitionpath.field", "country")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+  }
+
+  // ==========================================================================
+  // Limit pushdown tests
+  // ==========================================================================
+
+  @Test
+  def testLimitReducesRowCount(): Unit = {
+    val path = basePath() + "/limit_basic"
+    writeTestData(path, "limit_basic")
+
+    val df = spark.read.format("hudi_v2").load(path).limit(3)
+    assertEquals(3, df.count())
+  }
+
+  @Test
+  def testLimitGreaterThanTableSize(): Unit = {
+    val path = basePath() + "/limit_greater"
+    writeTestData(path, "limit_greater", numRecords = 5)
+
+    val df = spark.read.format("hudi_v2").load(path).limit(100)
+    assertEquals(5, df.count())
+  }
+
+  @Test
+  def testLimitWithFilter(): Unit = {
+    val path = basePath() + "/limit_filter"
+    writePartitionedTestData(path, "limit_filter")
+
+    val df = spark.read.format("hudi_v2").load(path)
+      .filter("country = 'US'")
+      .limit(1)
+    assertEquals(1, df.count())
+
+    val country = df.select("country").collect().head.getString(0)
+    assertEquals("US", country)
+  }
+
+  @Test
+  def testLimitDsv1VsDsv2(): Unit = {
+    val path = basePath() + "/limit_v1_v2"
+    writeTestData(path, "limit_v1_v2", numRecords = 10)
+
+    val v1Count = spark.read.format("hudi").load(path).limit(5).count()
+    val v2Count = spark.read.format("hudi_v2").load(path).limit(5).count()
+    assertEquals(v1Count, v2Count)
+    assertEquals(5, v2Count)
+  }
+
+  @Test
+  def testLimitOne(): Unit = {
+    val path = basePath() + "/limit_one"
+    writeTestData(path, "limit_one", numRecords = 10)
+
+    val df = spark.read.format("hudi_v2").load(path).limit(1)
+    assertEquals(1, df.count())
+  }
+
+  @Test
+  def testExplainShowsLimitInfo(): Unit = {
+    val path = basePath() + "/limit_explain"
+    writeTestData(path, "limit_explain", numRecords = 5)
+
+    val df = spark.read.format("hudi_v2").load(path).limit(3)
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(plan.contains("BatchScan"), s"Expected BatchScan in plan:\n$plan")
+    assertTrue(plan.contains("PushedLimit"), s"Expected PushedLimit in plan:\n$plan")
+  }
+
+  // ==========================================================================
+  // Statistics reporting tests
+  // ==========================================================================
+
+  @Test
+  def testStatisticsReportsSizeInBytes(): Unit = {
+    val path = basePath() + "/stats_size"
+    writeTestData(path, "stats_size", numRecords = 10)
+
+    val df = spark.read.format("hudi_v2").load(path)
+    val plan = df.queryExecution.optimizedPlan
+    val stats = plan.stats
+
+    assertTrue(stats.sizeInBytes > 0, s"Expected positive sizeInBytes, got: ${stats.sizeInBytes}")
+  }
+
+  @Test
+  def testStatisticsWithNoMatchFilter(): Unit = {
+    val path = basePath() + "/stats_no_match"
+    val _spark = spark
+    import _spark.implicits._
+
+    // Write one row so the table has metadata and a base file
+    Seq((1, "Alice", 100.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "stats_no_match")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    // Apply a filter that matches nothing; the table still has physical files
+    val df = spark.read.format("hudi_v2").load(path).filter("id < 0")
+    val count = df.count()
+    assertEquals(0L, count, "Expected zero rows for no-match filter")
+
+    // Statistics should still reflect the underlying file sizes
+    val plan = df.queryExecution.optimizedPlan
+    val stats = plan.stats
+    assertTrue(stats.sizeInBytes >= 0,
+      s"Expected non-negative sizeInBytes, got: ${stats.sizeInBytes}")
+  }
+
+  // ==========================================================================
+  // Aggregate pushdown tests (conditional on column stats availability)
+  // ==========================================================================
+
+  @Test
+  def testCountStarWithoutColumnStats(): Unit = {
+    // Without column stats enabled, COUNT(*) should still return correct result
+    // (falls back to scanning all files)
+    val path = basePath() + "/count_no_stats"
+    writeTestData(path, "count_no_stats", numRecords = 5)
+
+    val count = spark.read.format("hudi_v2").load(path)
+      .selectExpr("count(*)").collect().head.getLong(0)
+    assertEquals(5, count)
+  }
+
+  @Test
+  def testCountStarDsv1VsDsv2(): Unit = {
+    val path = basePath() + "/count_v1_v2"
+    writeTestData(path, "count_v1_v2", numRecords = 8)
+
+    val v1Count = spark.read.format("hudi").load(path)
+      .selectExpr("count(*)").collect().head.getLong(0)
+    val v2Count = spark.read.format("hudi_v2").load(path)
+      .selectExpr("count(*)").collect().head.getLong(0)
+    assertEquals(v1Count, v2Count)
+  }
+
+  @Test
+  def testMinMaxWithoutColumnStats(): Unit = {
+    val path = basePath() + "/minmax_no_stats"
+    writeTestData(path, "minmax_no_stats", numRecords = 5)
+
+    val row = spark.read.format("hudi_v2").load(path)
+      .selectExpr("min(amount)", "max(amount)").collect().head
+
+    assertEquals(100.0, row.getDouble(0))
+    assertEquals(500.0, row.getDouble(1))
+  }
+
+  @Test
+  def testAggregateWithGroupByNotPushed(): Unit = {
+    val path = basePath() + "/agg_groupby"
+    writePartitionedTestData(path, "agg_groupby")
+
+    // GROUP BY should prevent aggregate pushdown, but still return correct results
+    val rows = spark.read.format("hudi_v2").load(path)
+      .groupBy("country").count()
+      .collect().map(r => (r.getString(0), r.getLong(1))).sortBy(_._1)
+
+    assertEquals("FR", rows(0)._1)
+    assertEquals(2, rows(0)._2)
+    assertEquals("UK", rows(1)._1)
+    assertEquals(2, rows(1)._2)
+    assertEquals("US", rows(2)._1)
+    assertEquals(3, rows(2)._2)
+  }
+
+  @Test
+  def testCountWithPartitionFilter(): Unit = {
+    val path = basePath() + "/count_part_filter"
+    writePartitionedTestData(path, "count_part_filter")
+
+    val count = spark.read.format("hudi_v2").load(path)
+      .filter("country = 'US'")
+      .selectExpr("count(*)").collect().head.getLong(0)
+    assertEquals(3, count)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_3Adapter.scala
@@ -61,13 +61,18 @@ class Spark3_3Adapter extends BaseSpark3Adapter {
         case plan if !plan.resolved => None
         // NOTE: When resolving Hudi table we allow [[Filter]]s and [[Project]]s be applied
         //       on top of it
-        case PhysicalOperation(_, _, DataSourceV2Relation(v2: V2TableWithV1Fallback, _, _, _, _)) if isHoodieTable(v2.v1Table) =>
+        case PhysicalOperation(_, _, DataSourceV2Relation(v2: V2TableWithV1Fallback, _, _, _, _)) if isHoodieTable(v2) =>
           Some(v2.v1Table)
         case ResolvedTable(_, _, V1Table(v1Table), _) if isHoodieTable(v1Table) =>
           Some(v1Table)
         case _ => None
       }
     }
+  }
+
+  def isHoodieTable(v2Table: V2TableWithV1Fallback): Boolean = {
+    val className = v2Table.getClass.getName
+    className.contains("HoodieInternalV2Table") || className.contains("HoodieSparkV2Table")
   }
 
   override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark33Analysis.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark33Analysis.scala
@@ -27,15 +27,6 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig
 import org.apache.spark.sql.hudi.catalog.HoodieInternalV2Table
 
-/**
- * NOTE: PLEASE READ CAREFULLY
- *
- * Since Hudi relations don't currently implement DS V2 Read API, we have to fallback to V1 here.
- * Such fallback will have considerable performance impact, therefore it's only performed in cases
- * where V2 API have to be used. Currently only such use-case is using of Schema Evolution feature
- *
- * Check out HUDI-4178 for more details
- */
 case class HoodieSpark33DataSourceV2ToV1Fallback(sparkSession: SparkSession) extends Rule[LogicalPlan]
   with ProvidesHoodieConfig {
 

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_4Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_4Adapter.scala
@@ -62,13 +62,18 @@ class Spark3_4Adapter extends BaseSpark3Adapter {
         case plan if !plan.resolved => None
         // NOTE: When resolving Hudi table we allow [[Filter]]s and [[Project]]s be applied
         //       on top of it
-        case PhysicalOperation(_, _, DataSourceV2Relation(v2: V2TableWithV1Fallback, _, _, _, _)) if isHoodieTable(v2.v1Table) =>
+        case PhysicalOperation(_, _, DataSourceV2Relation(v2: V2TableWithV1Fallback, _, _, _, _)) if isHoodieTable(v2) =>
           Some(v2.v1Table)
         case ResolvedTable(_, _, V1Table(v1Table), _) if isHoodieTable(v1Table) =>
           Some(v1Table)
         case _ => None
       }
     }
+  }
+
+  def isHoodieTable(v2Table: V2TableWithV1Fallback): Boolean = {
+    val className = v2Table.getClass.getName
+    className.contains("HoodieInternalV2Table") || className.contains("HoodieSparkV2Table")
   }
 
   override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark34Analysis.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark34Analysis.scala
@@ -27,15 +27,6 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig
 import org.apache.spark.sql.hudi.catalog.HoodieInternalV2Table
 
-/**
- * NOTE: PLEASE READ CAREFULLY
- *
- * Since Hudi relations don't currently implement DS V2 Read API, we have to fallback to V1 here.
- * Such fallback will have considerable performance impact, therefore it's only performed in cases
- * where V2 API have to be used. Currently only such use-case is using of Schema Evolution feature
- *
- * Check out HUDI-4178 for more details
- */
 case class HoodieSpark34DataSourceV2ToV1Fallback(sparkSession: SparkSession) extends Rule[LogicalPlan]
   with ProvidesHoodieConfig {
 

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
@@ -71,7 +71,8 @@ class Spark3_5Adapter extends BaseSpark3Adapter {
   }
 
   def isHoodieTable(v2Table: V2TableWithV1Fallback): Boolean = {
-    v2Table.getClass.getName.contains("HoodieInternalV2Table")
+    val className = v2Table.getClass.getName
+    className.contains("HoodieInternalV2Table") || className.contains("HoodieSparkV2Table")
   }
 
   override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark35Analysis.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark35Analysis.scala
@@ -35,15 +35,6 @@ import org.apache.spark.sql.sources.InsertableRelation
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.PartitioningUtils.normalizePartitionSpec
 
-/**
- * NOTE: PLEASE READ CAREFULLY
- *
- * Since Hudi relations don't currently implement DS V2 Read API, we have to fallback to V1 here.
- * Such fallback will have considerable performance impact, therefore it's only performed in cases
- * where V2 API have to be used. Currently only such use-case is using of Schema Evolution feature
- *
- * Check out HUDI-4178 for more details
- */
 case class HoodieSpark35DataSourceV2ToV1Fallback(sparkSession: SparkSession) extends Rule[LogicalPlan]
   with ProvidesHoodieConfig {
 

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
@@ -68,7 +68,8 @@ class Spark4_0Adapter extends BaseSpark4Adapter {
   }
 
   def isHoodieTable(v2Table: V2TableWithV1Fallback): Boolean = {
-    v2Table.getClass.getName.contains("HoodieInternalV2Table")
+    val className = v2Table.getClass.getName
+    className.contains("HoodieInternalV2Table") || className.contains("HoodieSparkV2Table")
   }
 
   override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark40Analysis.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark40Analysis.scala
@@ -36,15 +36,6 @@ import org.apache.spark.sql.sources.InsertableRelation
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.PartitioningUtils.normalizePartitionSpec
 
-/**
- * NOTE: PLEASE READ CAREFULLY
- *
- * Since Hudi relations don't currently implement DS V2 Read API, we have to fallback to V1 here.
- * Such fallback will have considerable performance impact, therefore it's only performed in cases
- * where V2 API have to be used. Currently only such use-case is using of Schema Evolution feature
- *
- * Check out HUDI-4178 for more details
- */
 case class HoodieSpark40DataSourceV2ToV1Fallback(sparkSession: SparkSession) extends Rule[LogicalPlan]
   with ProvidesHoodieConfig {
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New DSv2 data source ("hudi_v2") with service registration for automatic discovery.
  * Config option to opt into DSv2 reads.
  * DSv2 read path adds snapshot batch scans, local/materialized scans, partitioned-parquet readers, pushdowns (filters, columns, limit, aggregates) and reports scan statistics. Limit pushdown is treated as partial, enforcing a final local limit step.
* **Tests**
  * Added comprehensive functional tests covering DSv2 reads, pushdowns, limits, aggregates, statistics, and DSv1/DSv2 coexistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->